### PR TITLE
fix(movesense): default namePrefix to 'Movesense'

### DIFF
--- a/packages/carp_movesense_package/CHANGELOG.md
+++ b/packages/carp_movesense_package/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.0.1
+
+* default `namePrefix` to `'Movesense'` (mirroring `PolarDevice`), so BLE scan filtering works for Movesense devices deployed from CAWS without an explicit prefix
+
 ## 3.0.0
 
 * **BREAKING (dependency only)**: migrated from the [`mdsflutter`](https://pub.dev/packages/mdsflutter) plugin to the [`carp_movesense_flutter`](https://pub.dev/packages/carp_movesense_flutter) plugin.

--- a/packages/carp_movesense_package/lib/carp_movesense_package.g.dart
+++ b/packages/carp_movesense_package/lib/carp_movesense_package.g.dart
@@ -218,6 +218,7 @@ MovesenseDevice _$MovesenseDeviceFromJson(Map<String, dynamic> json) =>
         roleName:
             json['roleName'] as String? ?? MovesenseDevice.DEFAULT_ROLE_NAME,
         isOptional: json['isOptional'] as bool? ?? true,
+        namePrefix: json['namePrefix'] as String? ?? 'Movesense',
       )
       ..$type = json['__type'] as String?
       ..defaultSamplingConfiguration =
@@ -232,7 +233,6 @@ MovesenseDevice _$MovesenseDeviceFromJson(Map<String, dynamic> json) =>
               ?.map((e) => e as String)
               .toList() ??
           []
-      ..namePrefix = json['namePrefix'] as String?
       ..minRssi = (json['minRssi'] as num?)?.toInt()
       ..allowDuplicates = json['allowDuplicates'] as bool? ?? true
       ..timeout = json['timeout'] == null

--- a/packages/carp_movesense_package/lib/movesense_device_manager.dart
+++ b/packages/carp_movesense_package/lib/movesense_device_manager.dart
@@ -34,6 +34,7 @@ class MovesenseDevice extends BLEDevice<MovesenseDeviceRegistration> {
   MovesenseDevice({
     super.roleName = MovesenseDevice.DEFAULT_ROLE_NAME,
     super.isOptional = true,
+    super.namePrefix = 'Movesense',
   });
 
   @override

--- a/packages/carp_movesense_package/pubspec.yaml
+++ b/packages/carp_movesense_package/pubspec.yaml
@@ -1,5 +1,5 @@
 name: carp_movesense_package
-version: 3.0.0
+version: 3.0.1
 description: The CARP Movesense sampling package. Samples sensor data from the Movesense MD and ACTIVE (HR+, HR2) devices.
 homepage: https://github.com/cph-cachet/carp.sensing-flutter
 repository: https://github.com/cph-cachet/carp.sensing-flutter/tree/main/packages/carp_movesense_package


### PR DESCRIPTION
Mirrors `PolarDevice` (which defaults `namePrefix = 'Polar'`) so BLE scan filtering works for Movesense devices deployed from CAWS without an explicit `namePrefix`.

- constructor now sets `super.namePrefix = 'Movesense'`, so codegen emits `?? 'Movesense'` in the constructor call (no null-clobbering cascade) — CAWS-deserialized devices get the prefix too
- regenerated `.g.dart`
- bumped to `3.0.1`