### PR TITLE
Close the data manager before replacing it

### DIFF
--- a/backends/carp_backend/lib/carp_data_manager.dart
+++ b/backends/carp_backend/lib/carp_data_manager.dart
@@ -308,9 +308,7 @@ class CarpDataManager extends AbstractDataManager {
   @override
   Future<void> close() async {
     uploadTimer?.cancel();
-    uploadTimer = null;
     await _connectivitySubscription?.cancel();
-    _connectivitySubscription = null;
 
     // Stop receiving measurements before the final flush.
     await super.close();

--- a/backends/carp_backend/lib/carp_data_manager.dart
+++ b/backends/carp_backend/lib/carp_data_manager.dart
@@ -42,6 +42,7 @@ class CarpDataManager extends AbstractDataManager {
   late CarpDataEndPoint carpEndPoint;
   DataStreamBuffer buffer = DataStreamBuffer();
   Timer? uploadTimer;
+  StreamSubscription<List<ConnectivityResult>>? _connectivitySubscription;
   List<ConnectivityResult> _connectivity = [];
 
   /// Make sure to create and initialize the [CarpDataManager].
@@ -87,7 +88,7 @@ class CarpDataManager extends AbstractDataManager {
       'CarpService is not configured -- cannot upload data to this end point.',
     );
 
-    buffer.initialize(deployment, measurements);
+    await buffer.initialize(deployment, measurements);
 
     // Set up a timer that uploads data on a regular basis depending on debug level
     int uploadInterval = Settings().debugLevel == DebugLevel.debug
@@ -101,7 +102,7 @@ class CarpDataManager extends AbstractDataManager {
 
     // Check the current connectivity status and listen for changes
     Connectivity().checkConnectivity().then((status) => connectivity = status);
-    Connectivity().onConnectivityChanged.listen(
+    _connectivitySubscription = Connectivity().onConnectivityChanged.listen(
       (status) => connectivity = status,
     );
 
@@ -307,8 +308,17 @@ class CarpDataManager extends AbstractDataManager {
   @override
   Future<void> close() async {
     uploadTimer?.cancel();
-    await uploadBufferedMeasurements();
+    uploadTimer = null;
+    await _connectivitySubscription?.cancel();
+    _connectivitySubscription = null;
+
+    // Stop receiving measurements before the final flush.
     await super.close();
+    await uploadBufferedMeasurements();
+
+    // Only detach from the buffer. Its database is shared app-wide (a single
+    // `carp-data.db`), so closing it would break the replacement manager.
+    await buffer.detach();
   }
 
   @override

--- a/backends/carp_backend/lib/data_stream_buffer.dart
+++ b/backends/carp_backend/lib/data_stream_buffer.dart
@@ -8,7 +8,8 @@
 part of 'carp_backend.dart';
 
 /// A local buffer of data streams using the [SQLiteDataManager].
-/// Works as a singleton accessed by `DataStreamBuffer()`.
+/// Works as a singleton accessed by `DataStreamBuffer()`, since it is backed
+/// by a single, app-wide `carp-data.db` file.
 class DataStreamBuffer {
   SmartphoneDeployment? _deployment;
   final _manager = SQLiteDataManager();
@@ -32,7 +33,7 @@ class DataStreamBuffer {
   ) async {
     info('Initializing $runtimeType...');
     _deployment = deployment;
-    _manager.configure(
+    await _manager.configure(
       dataEndPoint: SQLiteDataEndPoint(),
       deployment: deployment,
       measurements: measurements,
@@ -145,6 +146,15 @@ class DataStreamBuffer {
       '$runtimeType - cleaned up. '
       'N=$count records ${delete ? 'deleted' : 'marked as uploaded'}.',
     );
+  }
+
+  /// Stop buffering measurements, but keep the database and its data intact.
+  ///
+  /// Used when a [CarpDataManager] is replaced on a deployment update: the
+  /// database is shared app-wide, so it must outlive any single manager.
+  Future<void> detach() async {
+    await _manager.close();
+    _deployment = null;
   }
 
   /// Close this buffer. No more data can be added.

--- a/backends/carp_backend/pubspec.yaml
+++ b/backends/carp_backend/pubspec.yaml
@@ -64,6 +64,7 @@ dev_dependencies:
   test: any
   flutter_lints: any
   shared_preferences: ^2.5.3
+  sqflite_common_ffi: any
 
 flutter:
   uses-material-design: true # need this since both RP and carp_webservices uses MD

--- a/backends/carp_backend/test/data_stream_buffer_test.dart
+++ b/backends/carp_backend/test/data_stream_buffer_test.dart
@@ -1,0 +1,54 @@
+import 'dart:async';
+
+import 'package:carp_backend/carp_backend.dart';
+import 'package:carp_core/carp_core.dart' hide Smartphone;
+import 'package:carp_mobile_sensing/carp_mobile_sensing.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+import 'package:test/test.dart';
+
+/// [CarpDataManager.onMeasurement] is a no-op - measurements are written to
+/// SQLite by the [DataStreamBuffer]'s own subscription. So a replaced manager
+/// must detach from the buffer, or it keeps writing. The buffer is a singleton
+/// backed by one app-wide `carp-data.db`, so it must be detached from, never
+/// closed. See issue #598.
+void main() {
+  sqfliteFfiInit();
+  databaseFactory = databaseFactoryFfi;
+
+  setUpAll(() => CarpMobileSensing.ensureInitialized());
+
+  test('detach stops buffering but keeps the database open', () async {
+    final buffer = DataStreamBuffer();
+    final deployment = SmartphoneDeployment(
+      deviceConfiguration: Smartphone(roleName: 'phone'),
+      registration: DeviceRegistration(),
+    );
+    final measurements = StreamController<Measurement>.broadcast();
+    await deleteDatabase(
+      '${await getDatabasesPath()}/${SQLiteDataManager.DATABASE_NAME}.db',
+    );
+
+    await buffer.initialize(deployment, measurements.stream);
+
+    measurements.add(Measurement.fromData(Error(message: 'buffered')));
+    await Future<void>.delayed(const Duration(milliseconds: 50));
+    expect(await _rowCount(buffer), 1);
+
+    await buffer.detach();
+
+    // No further writes from the detached deployment...
+    measurements.add(Measurement.fromData(Error(message: 'after detach')));
+    await Future<void>.delayed(const Duration(milliseconds: 50));
+    expect(await _rowCount(buffer), 1);
+
+    // ...but the database stays open so a replacement manager can use it,
+    // and the un-uploaded row is still there.
+    expect(buffer.database!.isOpen, isTrue);
+
+    await measurements.close();
+  });
+}
+
+Future<int> _rowCount(DataStreamBuffer buffer) async =>
+    (await buffer.database!.query(SQLiteDataManager.MEASUREMENT_TABLE_NAME))
+        .length;

--- a/carp_mobile_sensing/lib/domain/services/data_manager.dart
+++ b/carp_mobile_sensing/lib/domain/services/data_manager.dart
@@ -138,7 +138,7 @@ abstract class AbstractDataManager implements DataManager {
   @mustCallSuper
   Future<void> close() async {
     info('Closing $runtimeType...');
-    _subscription?.cancel();
+    await _subscription?.cancel();
     addEvent(DataManagerEvent(DataManagerEventTypes.closed));
   }
 

--- a/carp_mobile_sensing/lib/runtime/study_controller.dart
+++ b/carp_mobile_sensing/lib/runtime/study_controller.dart
@@ -151,10 +151,12 @@ class SmartphoneStudyController {
     // tryRegisterRemainingDevicesToRegister();
     // await tryReregisterRemainingDevices();
 
-    // Initialize the data manager
-    if (dataEndPoint != null) {
-      _dataManager = DataManagerRegistry().create(dataEndPoint!.type);
-    }
+    // Close the existing data manager before replacing it - otherwise its
+    // timer and subscriptions stay alive and keep handling measurements.
+    await _dataManager?.close();
+    _dataManager = dataEndPoint == null
+        ? null
+        : DataManagerRegistry().create(dataEndPoint!.type);
 
     if (_dataManager == null) {
       warning(

--- a/carp_mobile_sensing/test/data_manager_test.dart
+++ b/carp_mobile_sensing/test/data_manager_test.dart
@@ -1,0 +1,56 @@
+import 'dart:async';
+
+import 'package:carp_core/carp_core.dart' hide Smartphone;
+import 'package:carp_mobile_sensing/carp_mobile_sensing.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+import 'package:test/test.dart';
+
+/// When a new deployment arrives, [SmartphoneStudyController] closes the
+/// existing data manager before replacing it. If closing does not actually
+/// cancel the measurement subscription, the replaced manager keeps writing and
+/// one measurement ends up stored twice - see issue #598.
+void main() {
+  sqfliteFfiInit();
+  databaseFactory = databaseFactoryFfi;
+
+  setUpAll(() => CarpMobileSensing.ensureInitialized());
+
+  test('a closed data manager stops writing measurements', () async {
+    final deployment = SmartphoneDeployment(
+      deviceConfiguration: Smartphone(roleName: 'phone'),
+      registration: DeviceRegistration(),
+    );
+    final measurements = StreamController<Measurement>.broadcast();
+    await deleteDatabase(
+      '${await getDatabasesPath()}/${SQLiteDataManager.DATABASE_NAME}.db',
+    );
+
+    Future<void> configure(SQLiteDataManager manager) => manager.configure(
+      dataEndPoint: SQLiteDataEndPoint(),
+      deployment: deployment,
+      measurements: measurements.stream,
+    );
+
+    final replaced = SQLiteDataManager();
+    await configure(replaced);
+
+    // The deployment update: close before replacing, as the controller does.
+    await replaced.close();
+    final replacement = SQLiteDataManager();
+    await configure(replacement);
+
+    measurements.add(Measurement.fromData(Error(message: 'once')));
+    await Future<void>.delayed(const Duration(milliseconds: 50));
+
+    // One measurement must yield one row - not one per manager.
+    expect(
+      (await replacement.database!.query(
+        SQLiteDataManager.MEASUREMENT_TABLE_NAME,
+      )).length,
+      1,
+    );
+
+    await measurements.close();
+    await replacement.database?.close();
+  });
+}


### PR DESCRIPTION
Closes #598.

On a deployment update, `SmartphoneStudyController` created a new data manager and overwrote the reference to the old one. The old manager stayed subscribed to the study's measurement stream, so both managers handled every measurement — duplicate SQLite rows and duplicate uploads.

## `carp_mobile_sensing`

**What:** `SmartphoneStudyController` awaits `_dataManager.close()` before assigning the replacement. `AbstractDataManager.close()` awaits the subscription cancel.

**Why:** The controller owns the manager, so it must release it before dropping the reference. `close()` is awaited by that caller to know the old manager is done, so it must not complete while still subscribed.

## `carp_backend`

**What:** Added `DataStreamBuffer.detach()` and call it from `CarpDataManager.close()`. Also store and cancel the connectivity subscription, and await `buffer.initialize()`.

**Why:** `CarpDataManager.onMeasurement` is a no-op — measurements reach SQLite through the `DataStreamBuffer`'s own subscription. Closing the manager therefore did not stop it writing, and a replaced manager kept buffering measurements from the previous deployment.

`detach()` cancels that subscription but deliberately leaves the database open: the buffer is a singleton backed by a single app-wide `carp-data.db`, so closing it would break the replacement manager that is already writing to it.

The connectivity subscription was never stored in a field, so it could never be cancelled.

## Tests

Both assert the reported symptom — one measurement, one row — and each was verified to fail without its fix:

| Test | Reverting the fix gives |
|---|---|
| `carp_mobile_sensing/test/data_manager_test.dart` | `Expected: <1>, Actual: <2>` |
| `carp_backend/test/data_stream_buffer_test.dart` | `Expected: <1>, Actual: <2>` |

## Note on the third bullet in #598

> Each `CarpDataManager` owns a separate `DataStreamBuffer` so closing one manager cannot affect another.

Not implemented, deliberately. `SQLiteDataManager` hardcodes `DATABASE_NAME = 'carp-data'` with no deployment id and opens it with `singleInstance: true`, so per-instance buffers would still share one file and one handle — the isolation would be nominal only. Worse, giving each manager its own buffer and letting it close that buffer makes the old manager close the database out from under the new one, which silently drops measurements (`SQLiteDataManager.onMeasurement` returns early when the database is closed).

Real per-deployment isolation needs per-deployment database files plus a migration for the existing `carp-data.db`. That is a separate change; suggest amending that bullet on the issue.
