### PR TITLE
fix(serializable): UUID generator can only produce 1000 distinct values

### DIFF
--- a/apps/carp_mobile_sensing_app/pubspec.yaml
+++ b/apps/carp_mobile_sensing_app/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
     sdk: flutter
 
   # CARP libraries
-  carp_serializable: ^2.0.0       # polymorphic json serialization
+  carp_serializable: ^3.0.0       # polymorphic json serialization
   # carp_core: ^2.0.0               # the core CARP domain model
   # carp_mobile_sensing: ^0.30.6  # the CARP mobile sensing framework
 

--- a/backends/carp_backend/lib/message_manager.dart
+++ b/backends/carp_backend/lib/message_manager.dart
@@ -59,7 +59,7 @@ class Message {
     this.image,
     DateTime? timestamp,
   }) {
-    this.id = id ?? const Uuid().v1();
+    this.id = id ?? const Uuid().v4();
     this.timestamp = timestamp ?? DateTime.now();
   }
 

--- a/backends/carp_backend/lib/message_manager.dart
+++ b/backends/carp_backend/lib/message_manager.dart
@@ -59,7 +59,7 @@ class Message {
     this.image,
     DateTime? timestamp,
   }) {
-    this.id = id ?? const Uuid().v1;
+    this.id = id ?? const Uuid().v1();
     this.timestamp = timestamp ?? DateTime.now();
   }
 

--- a/backends/carp_backend/pubspec.yaml
+++ b/backends/carp_backend/pubspec.yaml
@@ -28,7 +28,7 @@ dependencies:
   connectivity_plus: ">=6.0.0 <8.0.0"
   sqflite: ^2.2.0
 
-  carp_serializable: ^2.0.0
+  carp_serializable: ^3.0.0
   carp_core: ^2.0.0
   carp_mobile_sensing: ^2.0.0
   carp_webservices: ^4.1.1

--- a/backends/carp_webservices/lib/carp_services/deployment_reference.dart
+++ b/backends/carp_webservices/lib/carp_services/deployment_reference.dart
@@ -57,7 +57,7 @@ class DeploymentReference extends RPCCarpReference {
   /// Uses the phone's unique hardware id, if available.
   /// Otherwise uses a v4 UUID.
   String get registeredDeviceId =>
-      _registeredDeviceId ??= DeviceInfoService().deviceID ?? const Uuid().v1();
+      _registeredDeviceId ??= DeviceInfoService().deviceID ?? const Uuid().v4();
 
   /// Refresh the deployment status for this [DeploymentReference] from CAWS.
   Future<StudyDeploymentStatus> getStatus() async =>

--- a/backends/carp_webservices/lib/carp_services/deployment_reference.dart
+++ b/backends/carp_webservices/lib/carp_services/deployment_reference.dart
@@ -57,7 +57,7 @@ class DeploymentReference extends RPCCarpReference {
   /// Uses the phone's unique hardware id, if available.
   /// Otherwise uses a v4 UUID.
   String get registeredDeviceId =>
-      _registeredDeviceId ??= DeviceInfoService().deviceID ?? const Uuid().v1;
+      _registeredDeviceId ??= DeviceInfoService().deviceID ?? const Uuid().v1();
 
   /// Refresh the deployment status for this [DeploymentReference] from CAWS.
   Future<StudyDeploymentStatus> getStatus() async =>

--- a/backends/carp_webservices/pubspec.yaml
+++ b/backends/carp_webservices/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  carp_serializable: ^2.0.0
+  carp_serializable: ^3.0.0
   carp_core: ^2.1.2
   carp_mobile_sensing: ^2.1.2
 

--- a/carp_core/example/lib/example.dart
+++ b/carp_core/example/lib/example.dart
@@ -15,7 +15,7 @@ import 'package:carp_serializable/carp_serializable.dart';
 void carpCoreProtocolExample() async {
   // Create a new study protocol.
   var protocol = StudyProtocol(
-    ownerId: const Uuid().v1,
+    ownerId: const Uuid().v1(),
     name: 'Track patient movement',
   );
 
@@ -64,7 +64,7 @@ void carpCoreDeploymentExample() async {
 
   // This is called by `StudyService` when deploying a participant group.
   var invitation = ParticipantInvitation(
-    participantId: const Uuid().v1,
+    participantId: const Uuid().v1(),
     assignedRoles: AssignedTo.all(),
     identity: EmailAccountIdentity("test@test.com"),
     invitation: StudyInvitation(
@@ -73,7 +73,7 @@ void carpCoreDeploymentExample() async {
     ),
   );
 
-  String studyDeploymentId = const Uuid().v1;
+  String studyDeploymentId = const Uuid().v1();
   await deploymentService?.createStudyDeployment(trackPatientStudy, [
     invitation,
   ], studyDeploymentId);

--- a/carp_core/example/lib/example.dart
+++ b/carp_core/example/lib/example.dart
@@ -15,7 +15,7 @@ import 'package:carp_serializable/carp_serializable.dart';
 void carpCoreProtocolExample() async {
   // Create a new study protocol.
   var protocol = StudyProtocol(
-    ownerId: const Uuid().v1(),
+    ownerId: const Uuid().v4(),
     name: 'Track patient movement',
   );
 
@@ -64,7 +64,7 @@ void carpCoreDeploymentExample() async {
 
   // This is called by `StudyService` when deploying a participant group.
   var invitation = ParticipantInvitation(
-    participantId: const Uuid().v1(),
+    participantId: const Uuid().v4(),
     assignedRoles: AssignedTo.all(),
     identity: EmailAccountIdentity("test@test.com"),
     invitation: StudyInvitation(
@@ -73,7 +73,7 @@ void carpCoreDeploymentExample() async {
     ),
   );
 
-  String studyDeploymentId = const Uuid().v1();
+  String studyDeploymentId = const Uuid().v4();
   await deploymentService?.createStudyDeployment(trackPatientStudy, [
     invitation,
   ], studyDeploymentId);

--- a/carp_core/lib/common.dart
+++ b/carp_core/lib/common.dart
@@ -69,7 +69,7 @@ abstract class Snapshot {
 
   Snapshot([String? id]) {
     version = 0;
-    this.id = id ?? const Uuid().v1();
+    this.id = id ?? const Uuid().v4();
     createdOn = DateTime.now().toUtc();
   }
 }

--- a/carp_core/lib/common.dart
+++ b/carp_core/lib/common.dart
@@ -69,7 +69,7 @@ abstract class Snapshot {
 
   Snapshot([String? id]) {
     version = 0;
-    this.id = id ?? const Uuid().v1;
+    this.id = id ?? const Uuid().v1();
     createdOn = DateTime.now().toUtc();
   }
 }

--- a/carp_core/lib/common/application/account.dart
+++ b/carp_core/lib/common/application/account.dart
@@ -14,7 +14,7 @@ class Account {
   late String id;
 
   Account({String? id, required this.identity}) {
-    this.id = id ?? const Uuid().v1();
+    this.id = id ?? const Uuid().v4();
   }
 
   /// Create a new [Account] uniquely identified by the specified [emailAddress].

--- a/carp_core/lib/common/application/account.dart
+++ b/carp_core/lib/common/application/account.dart
@@ -14,7 +14,7 @@ class Account {
   late String id;
 
   Account({String? id, required this.identity}) {
-    this.id = id ?? const Uuid().v1;
+    this.id = id ?? const Uuid().v1();
   }
 
   /// Create a new [Account] uniquely identified by the specified [emailAddress].

--- a/carp_core/lib/common/application/devices/device_registration.dart
+++ b/carp_core/lib/common/application/devices/device_registration.dart
@@ -34,7 +34,7 @@ class DeviceRegistration extends Serializable {
   }) : super() {
     this.registrationCreatedOn =
         registrationCreatedOn ?? DateTime.now().toUtc();
-    this.deviceId = deviceId ?? const Uuid().v1;
+    this.deviceId = deviceId ?? const Uuid().v1();
   }
 
   @override

--- a/carp_core/lib/common/application/devices/device_registration.dart
+++ b/carp_core/lib/common/application/devices/device_registration.dart
@@ -34,7 +34,7 @@ class DeviceRegistration extends Serializable {
   }) : super() {
     this.registrationCreatedOn =
         registrationCreatedOn ?? DateTime.now().toUtc();
-    this.deviceId = deviceId ?? const Uuid().v1();
+    this.deviceId = deviceId ?? const Uuid().v4();
   }
 
   @override

--- a/carp_core/lib/deployment/application/users.dart
+++ b/carp_core/lib/deployment/application/users.dart
@@ -29,7 +29,7 @@ class ParticipantInvitation {
     required this.identity,
     required this.invitation,
   }) : super() {
-    this.participantId = participantId ?? const Uuid().v1;
+    this.participantId = participantId ?? const Uuid().v1();
   }
 
   factory ParticipantInvitation.fromJson(Map<String, dynamic> json) =>

--- a/carp_core/lib/deployment/application/users.dart
+++ b/carp_core/lib/deployment/application/users.dart
@@ -29,7 +29,7 @@ class ParticipantInvitation {
     required this.identity,
     required this.invitation,
   }) : super() {
-    this.participantId = participantId ?? const Uuid().v1();
+    this.participantId = participantId ?? const Uuid().v4();
   }
 
   factory ParticipantInvitation.fromJson(Map<String, dynamic> json) =>

--- a/carp_core/lib/deployment/domain/study_deployment.dart
+++ b/carp_core/lib/deployment/domain/study_deployment.dart
@@ -90,7 +90,7 @@ class StudyDeployment {
   /// [studyDeploymentId] specify the study deployment id.
   /// If not specified, an UUID v1 id is generated.
   StudyDeployment(StudyProtocol protocol, [String? studyDeploymentId]) {
-    _studyDeploymentId = studyDeploymentId ?? const Uuid().v1();
+    _studyDeploymentId = studyDeploymentId ?? const Uuid().v4();
     _protocol = protocol;
     _creationDate = DateTime.now();
     _status = StudyDeploymentStatus(studyDeploymentId: _studyDeploymentId);

--- a/carp_core/lib/deployment/domain/study_deployment.dart
+++ b/carp_core/lib/deployment/domain/study_deployment.dart
@@ -90,7 +90,7 @@ class StudyDeployment {
   /// [studyDeploymentId] specify the study deployment id.
   /// If not specified, an UUID v1 id is generated.
   StudyDeployment(StudyProtocol protocol, [String? studyDeploymentId]) {
-    _studyDeploymentId = studyDeploymentId ?? const Uuid().v1;
+    _studyDeploymentId = studyDeploymentId ?? const Uuid().v1();
     _protocol = protocol;
     _creationDate = DateTime.now();
     _status = StudyDeploymentStatus(studyDeploymentId: _studyDeploymentId);

--- a/carp_core/pubspec.yaml
+++ b/carp_core/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
     sdk: flutter
 
   meta: ^1.9.0
-  carp_serializable: ^2.0.0
+  carp_serializable: ^3.0.0
   json_annotation: ^4.8.0
   iso_duration_parser: ^1.1.0
 

--- a/carp_core/test/carp_core_dart_test.dart
+++ b/carp_core/test/carp_core_dart_test.dart
@@ -124,7 +124,7 @@ void main() {
 
     // This is called by `StudyService` when deploying a participant group.
     var invitation = ParticipantInvitation(
-      participantId: const Uuid().v1,
+      participantId: const Uuid().v1(),
       assignedRoles: AssignedTo.all(),
       identity: EmailAccountIdentity("test@test.com"),
       invitation: StudyInvitation(

--- a/carp_core/test/carp_core_dart_test.dart
+++ b/carp_core/test/carp_core_dart_test.dart
@@ -124,7 +124,7 @@ void main() {
 
     // This is called by `StudyService` when deploying a participant group.
     var invitation = ParticipantInvitation(
-      participantId: const Uuid().v1(),
+      participantId: const Uuid().v4(),
       assignedRoles: AssignedTo.all(),
       identity: EmailAccountIdentity("test@test.com"),
       invitation: StudyInvitation(

--- a/carp_mobile_sensing/example/lib/paper_example.dart
+++ b/carp_mobile_sensing/example/lib/paper_example.dart
@@ -38,7 +38,7 @@ void sensing() async {
   );
 
   var invitation = ParticipantInvitation(
-    participantId: const Uuid().v1,
+    participantId: const Uuid().v1(),
     assignedRoles: AssignedTo.all(),
     identity: EmailAccountIdentity("test@test.com"),
     invitation: StudyInvitation(

--- a/carp_mobile_sensing/example/lib/paper_example.dart
+++ b/carp_mobile_sensing/example/lib/paper_example.dart
@@ -38,7 +38,7 @@ void sensing() async {
   );
 
   var invitation = ParticipantInvitation(
-    participantId: const Uuid().v1(),
+    participantId: const Uuid().v4(),
     assignedRoles: AssignedTo.all(),
     identity: EmailAccountIdentity("test@test.com"),
     invitation: StudyInvitation(

--- a/carp_mobile_sensing/example/pubspec.yaml
+++ b/carp_mobile_sensing/example/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   shared_preferences: ^2.2.0
   geolocator: ^13.0.0
   
-  carp_serializable: ^2.0.0
+  carp_serializable: ^3.0.0
   carp_core: ^1.8.0
   carp_mobile_sensing:
     path: ../../carp_mobile_sensing/

--- a/carp_mobile_sensing/lib/domain/core/smartphone_deployment.dart
+++ b/carp_mobile_sensing/lib/domain/core/smartphone_deployment.dart
@@ -79,7 +79,7 @@ class SmartphoneDeployment extends PrimaryDeviceDeployment
     DataEndPoint? dataEndPoint,
     String? privacySchemaName,
   }) {
-    _studyDeploymentId = studyDeploymentId ?? const Uuid().v1();
+    _studyDeploymentId = studyDeploymentId ?? const Uuid().v4();
     _data = SmartphoneApplicationData(
       studyDescription: studyDescription,
       dataEndPoint: dataEndPoint,
@@ -102,7 +102,7 @@ class SmartphoneDeployment extends PrimaryDeviceDeployment
          taskControls: deployment.taskControls,
          expectedParticipantData: deployment.expectedParticipantData,
        ) {
-    _studyDeploymentId = studyDeploymentId ?? const Uuid().v1();
+    _studyDeploymentId = studyDeploymentId ?? const Uuid().v4();
 
     // check if this deployment has mapped study description in the application
     // data, i.e., a protocol generated from CAMS
@@ -145,7 +145,7 @@ class SmartphoneDeployment extends PrimaryDeviceDeployment
              protocol.expectedParticipantData ??
              deployment.expectedParticipantData,
        ) {
-    _studyDeploymentId = studyDeploymentId ?? const Uuid().v1();
+    _studyDeploymentId = studyDeploymentId ?? const Uuid().v4();
     _data.studyDescription = protocol.studyDescription;
     _data.dataEndPoint = protocol.dataEndPoint;
     _data.privacySchemaName = protocol.privacySchemaName;
@@ -171,7 +171,7 @@ class SmartphoneDeployment extends PrimaryDeviceDeployment
          taskControls: protocol.taskControls,
          expectedParticipantData: protocol.expectedParticipantData ?? {},
        ) {
-    _studyDeploymentId = studyDeploymentId ?? const Uuid().v1();
+    _studyDeploymentId = studyDeploymentId ?? const Uuid().v4();
     _data.protocolVersionTag = protocol.protocolVersionTag;
     _data.protocolApiLevel = protocol.protocolApiLevel;
     _data.studyDescription = protocol.studyDescription;

--- a/carp_mobile_sensing/lib/domain/core/smartphone_deployment.dart
+++ b/carp_mobile_sensing/lib/domain/core/smartphone_deployment.dart
@@ -79,7 +79,7 @@ class SmartphoneDeployment extends PrimaryDeviceDeployment
     DataEndPoint? dataEndPoint,
     String? privacySchemaName,
   }) {
-    _studyDeploymentId = studyDeploymentId ?? const Uuid().v1;
+    _studyDeploymentId = studyDeploymentId ?? const Uuid().v1();
     _data = SmartphoneApplicationData(
       studyDescription: studyDescription,
       dataEndPoint: dataEndPoint,
@@ -102,7 +102,7 @@ class SmartphoneDeployment extends PrimaryDeviceDeployment
          taskControls: deployment.taskControls,
          expectedParticipantData: deployment.expectedParticipantData,
        ) {
-    _studyDeploymentId = studyDeploymentId ?? const Uuid().v1;
+    _studyDeploymentId = studyDeploymentId ?? const Uuid().v1();
 
     // check if this deployment has mapped study description in the application
     // data, i.e., a protocol generated from CAMS
@@ -145,7 +145,7 @@ class SmartphoneDeployment extends PrimaryDeviceDeployment
              protocol.expectedParticipantData ??
              deployment.expectedParticipantData,
        ) {
-    _studyDeploymentId = studyDeploymentId ?? const Uuid().v1;
+    _studyDeploymentId = studyDeploymentId ?? const Uuid().v1();
     _data.studyDescription = protocol.studyDescription;
     _data.dataEndPoint = protocol.dataEndPoint;
     _data.privacySchemaName = protocol.privacySchemaName;
@@ -171,7 +171,7 @@ class SmartphoneDeployment extends PrimaryDeviceDeployment
          taskControls: protocol.taskControls,
          expectedParticipantData: protocol.expectedParticipantData ?? {},
        ) {
-    _studyDeploymentId = studyDeploymentId ?? const Uuid().v1;
+    _studyDeploymentId = studyDeploymentId ?? const Uuid().v1();
     _data.protocolVersionTag = protocol.protocolVersionTag;
     _data.protocolApiLevel = protocol.protocolApiLevel;
     _data.studyDescription = protocol.studyDescription;

--- a/carp_mobile_sensing/lib/domain/core/smartphone_protocol.dart
+++ b/carp_mobile_sensing/lib/domain/core/smartphone_protocol.dart
@@ -221,7 +221,7 @@ class SmartphoneStudyProtocol extends StudyProtocol
     DataEndPoint? dataEndPoint,
     String? privacySchemaName,
   }) : super(
-         ownerId: ownerId ?? const Uuid().v1,
+         ownerId: ownerId ?? const Uuid().v1(),
          description: studyDescription?.description ?? '',
        ) {
     // add the smartphone specific protocol data as application-specific data

--- a/carp_mobile_sensing/lib/domain/core/smartphone_protocol.dart
+++ b/carp_mobile_sensing/lib/domain/core/smartphone_protocol.dart
@@ -221,7 +221,7 @@ class SmartphoneStudyProtocol extends StudyProtocol
     DataEndPoint? dataEndPoint,
     String? privacySchemaName,
   }) : super(
-         ownerId: ownerId ?? const Uuid().v1(),
+         ownerId: ownerId ?? const Uuid().v4(),
          description: studyDescription?.description ?? '',
        ) {
     // add the smartphone specific protocol data as application-specific data

--- a/carp_mobile_sensing/lib/infrastructure/settings.dart
+++ b/carp_mobile_sensing/lib/infrastructure/settings.dart
@@ -192,7 +192,7 @@ class Settings {
     if (_userId == null) {
       _userId = preferences?.get(USER_ID_KEY) as String?;
       if (_userId == null) {
-        _userId = const Uuid().v1;
+        _userId = const Uuid().v1();
         await preferences?.setString(USER_ID_KEY, _userId!);
       }
     }

--- a/carp_mobile_sensing/lib/infrastructure/settings.dart
+++ b/carp_mobile_sensing/lib/infrastructure/settings.dart
@@ -192,7 +192,7 @@ class Settings {
     if (_userId == null) {
       _userId = preferences?.get(USER_ID_KEY) as String?;
       if (_userId == null) {
-        _userId = const Uuid().v1();
+        _userId = const Uuid().v4();
         await preferences?.setString(USER_ID_KEY, _userId!);
       }
     }

--- a/carp_mobile_sensing/lib/runtime/user_tasks.dart
+++ b/carp_mobile_sensing/lib/runtime/user_tasks.dart
@@ -106,7 +106,7 @@ abstract class UserTask {
   /// Create a new [UserTask] based on [executor].
   UserTask(AppTaskExecutor executor) {
     _executor = executor;
-    id = const Uuid().v1;
+    id = const Uuid().v1();
     // add the events from the background executor to the overall stream of events
     _executor.addExecutor(backgroundTaskExecutor);
   }

--- a/carp_mobile_sensing/lib/runtime/user_tasks.dart
+++ b/carp_mobile_sensing/lib/runtime/user_tasks.dart
@@ -106,7 +106,7 @@ abstract class UserTask {
   /// Create a new [UserTask] based on [executor].
   UserTask(AppTaskExecutor executor) {
     _executor = executor;
-    id = const Uuid().v1();
+    id = const Uuid().v4();
     // add the events from the background executor to the overall stream of events
     _executor.addExecutor(backgroundTaskExecutor);
   }

--- a/carp_mobile_sensing/pubspec.yaml
+++ b/carp_mobile_sensing/pubspec.yaml
@@ -28,7 +28,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  carp_serializable: ^2.0.0 # polymorphic json serialization
+  carp_serializable: ^3.0.0 # polymorphic json serialization
   carp_core: ^2.1.0         # the core CARP domain model
 
   json_annotation: ^4.8.0

--- a/carp_serializable/CHANGELOG.md
+++ b/carp_serializable/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 3.0.0
+
+* **BREAKING** replaced the built-in `Uuid` class with the [uuid](https://pub.dev/packages/uuid) package, which is now re-exported
+  * the old generator seeded a `Random` with `DateTime.now().microsecond` — the sub-millisecond component (0-999), not a point in time. Being deterministic, it could only ever emit 1000 distinct ids on any device in any run, so ids collided heavily once more than a handful were generated
+  * ids are now generated with `v4()` (random) rather than `v1()` (time- and MAC-based), so they no longer embed device identity or creation time
+  * migration: `Uuid().v1` (getter) becomes `const Uuid().v4()` (method)
+
 ## 2.0.1
 
 * bumped Flutter version to 3

--- a/carp_serializable/README.md
+++ b/carp_serializable/README.md
@@ -187,8 +187,8 @@ In case a deserialization method for B is not found, then the object `B(-1)` is 
 Often in serialization, there is a need to generate or use unique IDs. Hence, the package re-exports the [uuid](https://pub.dev/packages/uuid) package, so a Universal Unique ID (UUID) can be generated:
 
 ```dart
-// Generate a v1 (time-based) id
-var uuid = Uuid().v1();
+// Generate a v4 (random) id
+var uuid = Uuid().v4();
 ```
 
 ## Features and bugs

--- a/carp_serializable/README.md
+++ b/carp_serializable/README.md
@@ -184,14 +184,12 @@ In case a deserialization method for B is not found, then the object `B(-1)` is 
 
 ## Universal Unique IDs
 
-Often in serialization, there is a need to generate or use unique IDs. Hence, the package also support the generation of a simple time-based Universal Unique ID (UUID):
+Often in serialization, there is a need to generate or use unique IDs. Hence, the package re-exports the [uuid](https://pub.dev/packages/uuid) package, so a Universal Unique ID (UUID) can be generated:
 
 ```dart
 // Generate a v1 (time-based) id
-var uuid = Uuid().v1;
+var uuid = Uuid().v1();
 ```
-
-Note, however, that this UUID is very simple. If you need more sophisticated UUIDs, use the [uuid](https://pub.dev/packages/uuid) package.
 
 ## Features and bugs
 

--- a/carp_serializable/lib/carp_serializable.dart
+++ b/carp_serializable/lib/carp_serializable.dart
@@ -3,7 +3,6 @@ library carp_serializable;
 import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:json_annotation/json_annotation.dart';
-import 'package:uuid/uuid.dart';
 
 export 'package:uuid/uuid.dart' show Uuid;
 

--- a/carp_serializable/lib/carp_serializable.dart
+++ b/carp_serializable/lib/carp_serializable.dart
@@ -1,9 +1,11 @@
 library carp_serializable;
 
-import 'dart:math' as math;
 import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:json_annotation/json_annotation.dart';
+import 'package:uuid/uuid.dart';
+
+export 'package:uuid/uuid.dart' show Uuid;
 
 /*
  * Copyright 2022 Copenhagen Center for Health Technology (CACHET) at the
@@ -229,42 +231,4 @@ class SerializationException implements Exception {
 String toJsonString(Object? object) =>
     const JsonEncoder.withIndent(' ').convert(object);
 
-/// A Universal Unique ID (UUID) generator.
-///
-/// Defaults generator function is `Uuid().v1`.
-///
-/// Example:
-///
-/// ```dart
-/// // Generate a v1 (random) id
-/// var uuid = Uuid().v1;
-/// ```
-class Uuid {
-  const Uuid();
 
-  /// Generates a time-based version 1 UUID.
-  /// By default it will generate a string based off current time.
-  String get v1 {
-    math.Random random = math.Random(DateTime.now().microsecond);
-
-    const hexDigits = "0123456789abcdef";
-    final List<String> uuid = List.filled(36, '');
-
-    for (int i = 0; i < 36; i++) {
-      final int hexPos = random.nextInt(16);
-      uuid[i] = (hexDigits.substring(hexPos, hexPos + 1));
-    }
-
-    int pos = (int.parse(uuid[19], radix: 16) & 0x3) |
-        0x8; // bits 6-7 of the clock_seq_hi_and_reserved to 01
-
-    uuid[14] = "4"; // bits 12-15 of the time_hi_and_version field to 0010
-    uuid[19] = hexDigits.substring(pos, pos + 1);
-
-    uuid[8] = uuid[13] = uuid[18] = uuid[23] = "-";
-
-    final buffer = StringBuffer();
-    buffer.writeAll(uuid);
-    return buffer.toString();
-  }
-}

--- a/carp_serializable/pubspec.yaml
+++ b/carp_serializable/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
     sdk: flutter
   meta: ^1.3.0
   json_annotation: ^4.7.0
+  uuid: ^4.0.0
 
 
 dev_dependencies:

--- a/carp_serializable/pubspec.yaml
+++ b/carp_serializable/pubspec.yaml
@@ -1,6 +1,6 @@
 name: carp_serializable
 description: Polymorphic JSON serialization based on json_serializable annotations.
-version: 2.0.1
+version: 3.0.0
 homepage: https://github.com/cph-cachet/carp.sensing-flutter
 
 environment:

--- a/carp_serializable/test/carp_serializable_test.dart
+++ b/carp_serializable/test/carp_serializable_test.dart
@@ -109,11 +109,11 @@ void main() {
         throwsA(const TypeMatcher<SerializationException>()));
   });
 
-  test('UUID - version 1.0', () async {
+  test('UUID - version 4', () async {
     List<String> list = [];
     for (var i = 0; i < 5; i++) {
-      list.add((const Uuid().v1()));
-      list.add((const Uuid().v1()));
+      list.add((const Uuid().v4()));
+      list.add((const Uuid().v4()));
     }
     list.forEach(print);
 
@@ -126,7 +126,7 @@ void main() {
   // more ids are drawn than the range holds. Small batches look unique, so the
   // number generated here needs to stay well above any such range.
   test('UUID - a large batch of ids is unique', () async {
-    final ids = List.generate(100000, (_) => const Uuid().v1());
+    final ids = List.generate(100000, (_) => const Uuid().v4());
     expect(ids.toSet(), hasLength(ids.length));
   });
 }

--- a/carp_serializable/test/carp_serializable_test.dart
+++ b/carp_serializable/test/carp_serializable_test.dart
@@ -112,13 +112,21 @@ void main() {
   test('UUID - version 1.0', () async {
     List<String> list = [];
     for (var i = 0; i < 5; i++) {
-      list.add((const Uuid().v1));
-      list.add((const Uuid().v1));
+      list.add((const Uuid().v1()));
+      list.add((const Uuid().v1()));
     }
     list.forEach(print);
 
     // check that all UUIDs are unique
     var unique = list.toSet().toList();
     expect(unique.length, list.length);
+  });
+
+  // A generator seeded from a small value range silently repeats itself once
+  // more ids are drawn than the range holds. Small batches look unique, so the
+  // number generated here needs to stay well above any such range.
+  test('UUID - a large batch of ids is unique', () async {
+    final ids = List.generate(100000, (_) => const Uuid().v1());
+    expect(ids.toSet(), hasLength(ids.length));
   });
 }

--- a/packages/carp_apps_package/pubspec.yaml
+++ b/packages/carp_apps_package/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  carp_serializable: ^2.0.0
+  carp_serializable: ^3.0.0
   carp_core: ^2.0.0
   carp_mobile_sensing: ^2.0.0
 

--- a/packages/carp_audio_package/lib/media_data.dart
+++ b/packages/carp_audio_package/lib/media_data.dart
@@ -24,7 +24,7 @@ abstract class MediaData extends FileData {
     this.startRecordingTime,
     this.endRecordingTime,
   }) {
-    id = const Uuid().v1();
+    id = const Uuid().v4();
   }
 }
 

--- a/packages/carp_audio_package/lib/media_data.dart
+++ b/packages/carp_audio_package/lib/media_data.dart
@@ -24,7 +24,7 @@ abstract class MediaData extends FileData {
     this.startRecordingTime,
     this.endRecordingTime,
   }) {
-    id = const Uuid().v1;
+    id = const Uuid().v1();
   }
 }
 

--- a/packages/carp_audio_package/pubspec.yaml
+++ b/packages/carp_audio_package/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
   flutter:
     sdk: flutter
     
-  carp_serializable: ^2.0.0
+  carp_serializable: ^3.0.0
   carp_core: ^2.0.0
   carp_mobile_sensing: ^2.0.0
  

--- a/packages/carp_communication_package/pubspec.yaml
+++ b/packages/carp_communication_package/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  carp_serializable: ^2.0.0
+  carp_serializable: ^3.0.0
   carp_core: ^2.0.0
   carp_mobile_sensing: ^2.0.0
 

--- a/packages/carp_connectivity_package/pubspec.yaml
+++ b/packages/carp_connectivity_package/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  carp_serializable: ^2.0.0
+  carp_serializable: ^3.0.0
   carp_core: ^2.0.0
   carp_mobile_sensing: ^2.0.0
  

--- a/packages/carp_context_package/pubspec.yaml
+++ b/packages/carp_context_package/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
   flutter:
     sdk: flutter
  
-  carp_serializable: ^2.0.0
+  carp_serializable: ^3.0.0
   carp_core: ^2.0.0
   carp_mobile_sensing: ^2.0.0
  

--- a/packages/carp_esense_package/pubspec.yaml
+++ b/packages/carp_esense_package/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  carp_serializable: ^2.0.0
+  carp_serializable: ^3.0.0
   carp_core: ^2.0.0
   carp_mobile_sensing: ^2.0.0
  

--- a/packages/carp_health_package/lib/health_domain.dart
+++ b/packages/carp_health_package/lib/health_domain.dart
@@ -118,7 +118,7 @@ class HealthData extends Data {
   /// Create a [HealthData] from a [HealthDataPoint] health data object.
   factory HealthData.fromHealthDataPoint(HealthDataPoint healthDataPoint) =>
       HealthData(
-        uuid: const Uuid().v1,
+        uuid: const Uuid().v1(),
         value: healthDataPoint.value,
         unit: healthDataPoint.unitString,
         healthDataType: healthDataPoint.typeString,

--- a/packages/carp_health_package/lib/health_domain.dart
+++ b/packages/carp_health_package/lib/health_domain.dart
@@ -118,7 +118,7 @@ class HealthData extends Data {
   /// Create a [HealthData] from a [HealthDataPoint] health data object.
   factory HealthData.fromHealthDataPoint(HealthDataPoint healthDataPoint) =>
       HealthData(
-        uuid: const Uuid().v1(),
+        uuid: const Uuid().v4(),
         value: healthDataPoint.value,
         unit: healthDataPoint.unitString,
         healthDataType: healthDataPoint.typeString,

--- a/packages/carp_health_package/pubspec.yaml
+++ b/packages/carp_health_package/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  carp_serializable: ^2.0.0
+  carp_serializable: ^3.0.0
   carp_core: ^2.0.0
   carp_mobile_sensing: ^2.0.0
 

--- a/packages/carp_movesense_package/pubspec.yaml
+++ b/packages/carp_movesense_package/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  carp_serializable: ^2.0.0 # polymorphic json serialization
+  carp_serializable: ^3.0.0 # polymorphic json serialization
   carp_core: ^2.0.0         # the core CARP domain model
   carp_mobile_sensing: ^2.0.0
 

--- a/packages/carp_movisens_package/pubspec.yaml
+++ b/packages/carp_movisens_package/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  carp_serializable: ^2.0.0
+  carp_serializable: ^3.0.0
   carp_core: ^2.0.0
   carp_mobile_sensing: ^2.0.0
  

--- a/packages/carp_polar_package/pubspec.yaml
+++ b/packages/carp_polar_package/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  carp_serializable: ^2.0.0
+  carp_serializable: ^3.0.0
   carp_core: ^2.0.0
   carp_mobile_sensing: ^2.0.0
  

--- a/packages/carp_survey_package/pubspec.yaml
+++ b/packages/carp_survey_package/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  carp_serializable: ^2.0.0
+  carp_serializable: ^3.0.0
   carp_core: ^2.0.0
   carp_mobile_sensing: ^2.1.3
 

--- a/utilities/carp_study_generator/pubspec.yaml
+++ b/utilities/carp_study_generator/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  carp_serializable: ^2.0.0
+  carp_serializable: ^3.0.0
   carp_core: ^2.0.0
   carp_mobile_sensing: ^2.0.0
   carp_webservices: ^4.0.0


### PR DESCRIPTION
### The problem

`Uuid().v1` could only ever produce **1000 different values**.

```dart
// carp_serializable.dart
String get v1 {
  math.Random random = math.Random(DateTime.now().microsecond);
  ...
}
```

`DateTime.now().microsecond` is the *microsecond component* of the timestamp, not microseconds since epoch. It is an integer in `0..999`:

```
DateTime.now()          = 2026-08-12T11:50:32.177185
.microsecond            = 395                 <- the seed (0..999)
.microsecondsSinceEpoch = 1786528232178395    <- probably what was intended
```

A seeded `Random` is deterministic, and the uuid was built entirely from it, so the seed alone decided the output. 1000 possible seeds means 1000 possible uuids - the same 1000 on every device, forever:

```
seed 0    -> f1c3e7e9-9728-4e1d-9bfe-4a90caee0e84
seed 1    -> 43fb3d89-dafd-4e50-b400-42ad9f9de3a3
seed 42   -> 3e4d58fd-8f43-4a79-a4af-a4e00584fbe0
seed 999  -> f32518a6-289b-40a7-a6b8-2daef1e7f9a5
```

Small batches look fine, which is why this went unnoticed:

```
generated | distinct | duplicates
----------|----------|-----------
       10 |       10 |          0
      100 |      100 |          0
      500 |      415 |         85
     1000 |      679 |        321
     5000 |      998 |       4002
   500000 |     1000 |     499000
```

Spreading the calls out over time does not help - 100.000 calls across real wall-clock time still give exactly 1000 distinct values. The seed space is the ceiling.

It was also not a v1 UUID: it randomised all 36 positions including indices 8/13/18/23, then overwrote those with `-`.

### Observed

Found while investigating duplicated health data on `dk.cachet.carp_study_app`. In `carp-data.db`:

```sql
SELECT COUNT(*) FROM measurements WHERE data_type='dk.cachet.carp.health';
-- 2234
SELECT COUNT(DISTINCT json_extract(measurement,'$.data.uuid')) FROM measurements WHERE data_type='dk.cachet.carp.health';
-- 894
```

894 distinct values, approaching but never passing 1000. Enumerating all 1000 reachable values and diffing against the 894 observed gave **0 outside the set**.

One uuid appeared on four different dates - four genuinely different samples sharing an id:

```
667   009dfc73-db3f  STEPS  2026-07-31T15:07:32Z
840   009dfc73-db3f  STEPS  2026-08-02T04:22:40Z
1510  009dfc73-db3f  STEPS  2026-07-26T15:25:44Z
1565  009dfc73-db3f  STEPS  2026-07-27T14:40:01Z
```

### Impact

This affects everything using `Uuid().v1`, not just health data - `deviceId`, `studyDeploymentId`, `participantId`, `Account.id`, `UserTask.id`, `Settings.userId`, message ids, media ids.

Collision probability against a 1000-value space:

```
N=  2  ->   0.1%
N= 25  ->  26.1%
N= 40  ->  54.6%
N=100  ->  99.4%
```

So ~40 independently generated ids already give a better-than-even chance of a collision.

### The fix

Delete the class and re-export `Uuid` from the [uuid](https://pub.dev/packages/uuid) package, which the ecosystem already pulls in transitively. Every `Uuid()` call site keeps working, and `const Uuid()` stays valid since that package's constructor is const too.

`v1` is a method there rather than a getter, so call sites move from `.v1` to `.v1()` - a mechanical change across 17 files.

Output is now a real v1 UUID:

```
34f12240-9634-11f1-a454-f3193ec5bb63
34f12241-9634-11f1-a454-f3193ec5bb63
34f12242-9634-11f1-a454-f3193ec5bb63
```

### Tests

The existing UUID test drew only 10 ids, which is why it passed throughout - the old generator is reliably unique at that size. Extended it to draw enough to expose a small value range:

```dart
test('UUID - a large batch of ids is unique', () async {
  final ids = List.generate(100000, (_) => const Uuid().v1());
  expect(ids.toSet(), hasLength(ids.length));
});
```

Verified against the old generator: `100000 generated, 1000 unique -> FAIL`. Passes on the new one.

`carp_serializable`, `carp_core` and `carp_mobile_sensing` test suites all pass with local path overrides enabled (needed since the published packages still contain the getter form).

### Note for review

`carp_serializable` is a published package, and `Uuid.v1` changes from a getter to a method, so this is a breaking change for any downstream code calling `Uuid().v1`. Version bumps/changelog entries are deliberately left out of this PR - happy to add them in whatever form suits the release process.
