### PR TITLE
chore: bump packages for carp_serializable ^3.0.0

### DIFF
--- a/backends/carp_backend/CHANGELOG.md
+++ b/backends/carp_backend/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.0
+
+* require `carp_serializable` ^3.0.0, which replaces the built-in `Uuid` with the [uuid](https://pub.dev/packages/uuid) package
+
 ## 2.0.1
 
 * Update carp_webservices to ^4.1.1

--- a/backends/carp_backend/pubspec.yaml
+++ b/backends/carp_backend/pubspec.yaml
@@ -1,5 +1,5 @@
 name: carp_backend
-version: 2.0.1
+version: 2.1.0
 description: CARP data backend for CARP Mobile Sensing. Supports downloading study deployments and uploading data from/to a CARP Web Service (CAWS) server.
 homepage: https://github.com/cph-cachet/carp.sensing-flutter
 repository: https://github.com/carp-dk/carp.sensing-flutter/tree/main/backends/carp_backend
@@ -29,9 +29,9 @@ dependencies:
   sqflite: ^2.2.0
 
   carp_serializable: ^3.0.0
-  carp_core: ^2.0.0
-  carp_mobile_sensing: ^2.0.0
-  carp_webservices: ^4.1.1
+  carp_core: ^2.2.0
+  carp_mobile_sensing: ^2.2.0
+  carp_webservices: ^4.2.0
 
   research_package: ^2.0.0
 

--- a/backends/carp_webservices/CHANGELOG.md
+++ b/backends/carp_webservices/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.2.0
+
+* require `carp_serializable` ^3.0.0, which replaces the built-in `Uuid` with the [uuid](https://pub.dev/packages/uuid) package
+
 ## 4.1.1
 
 * Fix of [#581](https://github.com/carp-dk/carp.sensing-flutter/issues/581)

--- a/backends/carp_webservices/pubspec.yaml
+++ b/backends/carp_webservices/pubspec.yaml
@@ -1,5 +1,5 @@
 name: carp_webservices
-version: 4.1.1
+version: 4.2.0
 description: Flutter API for accessing the CARP web services, including authentication, deployments, data, files, and collections of documents.
 homepage: https://github.com/cph-cachet/carp.sensing-flutter
 repository: https://github.com/carp-dk/carp.sensing-flutter/tree/main/backends/carp_webservices
@@ -25,8 +25,8 @@ dependencies:
     sdk: flutter
 
   carp_serializable: ^3.0.0
-  carp_core: ^2.1.2
-  carp_mobile_sensing: ^2.1.2
+  carp_core: ^2.2.0
+  carp_mobile_sensing: ^2.2.0
 
   http: ^1.6.0
   json_annotation: ^4.12.0

--- a/carp_core/CHANGELOG.md
+++ b/carp_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2.0
+
+* require `carp_serializable` ^3.0.0, which replaces the built-in `Uuid` with the [uuid](https://pub.dev/packages/uuid) package
+
 ## 2.1.2
 
 * fix of issue [#561](https://github.com/carp-dk/carp.sensing-flutter/issues/561)

--- a/carp_core/pubspec.yaml
+++ b/carp_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: carp_core
-version: 2.1.2
+version: 2.2.0
 description: The core domain model for the Copenhagen Research Platform (CARP) in Dart.
 
 # Note that the following URLs to GitHub should use the old 'cph-cachet' name. 

--- a/carp_mobile_sensing/CHANGELOG.md
+++ b/carp_mobile_sensing/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2.0
+
+* require `carp_serializable` ^3.0.0, which replaces the built-in `Uuid` with the [uuid](https://pub.dev/packages/uuid) package
+
 ## 2.1.7
 
 * resume a connectable device's task control executors when it connects after the study has started - previously they stayed paused and the device never sampled

--- a/carp_mobile_sensing/pubspec.yaml
+++ b/carp_mobile_sensing/pubspec.yaml
@@ -1,5 +1,5 @@
 name: carp_mobile_sensing
-version: 2.1.8
+version: 2.2.0
 description: Mobile Sensing Framework for Flutter. A software framework for collecting sensor data from the phone and attached wearable devices via probes. Can be extended.
 
 # Note that the following URLs to GitHub should use the old 'cph-cachet' name.
@@ -29,7 +29,7 @@ dependencies:
     sdk: flutter
 
   carp_serializable: ^3.0.0 # polymorphic json serialization
-  carp_core: ^2.1.0         # the core CARP domain model
+  carp_core: ^2.2.0         # the core CARP domain model
 
   json_annotation: ^4.8.0
   system_info2: ^4.0.0

--- a/packages/carp_apps_package/CHANGELOG.md
+++ b/packages/carp_apps_package/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.0
+
+* require `carp_serializable` ^3.0.0, which replaces the built-in `Uuid` with the [uuid](https://pub.dev/packages/uuid) package
+
 ## 2.0.0
 
 * upgrade to CARP Core and CAMS API level 2.0.0

--- a/packages/carp_apps_package/pubspec.yaml
+++ b/packages/carp_apps_package/pubspec.yaml
@@ -1,5 +1,5 @@
 name: carp_apps_package
-version: 2.0.0
+version: 2.1.0
 description: Apps sampling package for the CARP Mobile Sensing framework (Android only).
 homepage: https://github.com/cph-cachet/carp.sensing-flutter
 repository: https://github.com/cph-cachet/carp.sensing-flutter/tree/main/packages/carp_apps_package
@@ -25,8 +25,8 @@ dependencies:
     sdk: flutter
 
   carp_serializable: ^3.0.0
-  carp_core: ^2.0.0
-  carp_mobile_sensing: ^2.0.0
+  carp_core: ^2.2.0
+  carp_mobile_sensing: ^2.2.0
 
   app_usage: ^4.0.0
   installed_apps: ^2.0.0

--- a/packages/carp_audio_package/CHANGELOG.md
+++ b/packages/carp_audio_package/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.0
+
+* require `carp_serializable` ^3.0.0, which replaces the built-in `Uuid` with the [uuid](https://pub.dev/packages/uuid) package
+
 ## 2.0.0
 
 * upgrade to CARP Core and CAMS API level 2.0.0

--- a/packages/carp_audio_package/pubspec.yaml
+++ b/packages/carp_audio_package/pubspec.yaml
@@ -1,5 +1,5 @@
 name: carp_audio_package
-version: 2.0.0
+version: 2.1.0
 description: CARP Media Sampling Package. Samples audio, video, image, and noise.
 
 homepage: https://github.com/cph-cachet/carp.sensing-flutter
@@ -26,8 +26,8 @@ dependencies:
     sdk: flutter
     
   carp_serializable: ^3.0.0
-  carp_core: ^2.0.0
-  carp_mobile_sensing: ^2.0.0
+  carp_core: ^2.2.0
+  carp_mobile_sensing: ^2.2.0
  
   json_annotation: ^4.8.0
   permission_handler: '>=11.0.0 <13.0.0'

--- a/packages/carp_communication_package/CHANGELOG.md
+++ b/packages/carp_communication_package/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.0
+
+* require `carp_serializable` ^3.0.0, which replaces the built-in `Uuid` with the [uuid](https://pub.dev/packages/uuid) package
+
 ## 2.0.1
 
 * upgrade to CARP Core and CAMS API level 2.0.0

--- a/packages/carp_communication_package/pubspec.yaml
+++ b/packages/carp_communication_package/pubspec.yaml
@@ -1,5 +1,5 @@
 name: carp_communication_package
-version: 2.0.1
+version: 2.1.0
 description: CARP communication sampling package. Samples phone, sms, and calendar logs and activity.
 homepage: https://github.com/cph-cachet/carp.sensing-flutter
 repository: https://github.com/cph-cachet/carp.sensing-flutter/tree/main/packages/carp_communication_package
@@ -25,8 +25,8 @@ dependencies:
     sdk: flutter
 
   carp_serializable: ^3.0.0
-  carp_core: ^2.0.0
-  carp_mobile_sensing: ^2.0.0
+  carp_core: ^2.2.0
+  carp_mobile_sensing: ^2.2.0
 
   json_annotation: ^4.8.0
   another_telephony: ^0.4.0

--- a/packages/carp_connectivity_package/CHANGELOG.md
+++ b/packages/carp_connectivity_package/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.0
+
+* require `carp_serializable` ^3.0.0, which replaces the built-in `Uuid` with the [uuid](https://pub.dev/packages/uuid) package
+
 ## 2.0.0
 
 * upgrade to CARP Core and CAMS API level 2.0.0

--- a/packages/carp_connectivity_package/pubspec.yaml
+++ b/packages/carp_connectivity_package/pubspec.yaml
@@ -1,5 +1,5 @@
 name: carp_connectivity_package
-version: 2.0.0
+version: 2.1.0
 description: CARP connectivity sampling package. Samples connectivity status, bluetooth devices, and wifi access points.
 homepage: https://github.com/cph-cachet/carp.sensing-flutter
 repository: https://github.com/cph-cachet/carp.sensing-flutter/tree/main/packages/carp_connectivity_package
@@ -25,8 +25,8 @@ dependencies:
     sdk: flutter
 
   carp_serializable: ^3.0.0
-  carp_core: ^2.0.0
-  carp_mobile_sensing: ^2.0.0
+  carp_core: ^2.2.0
+  carp_mobile_sensing: ^2.2.0
  
   json_annotation: ^4.8.0
   connectivity_plus: ^7.0.0    # connectivity events

--- a/packages/carp_context_package/CHANGELOG.md
+++ b/packages/carp_context_package/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.0
+
+* require `carp_serializable` ^3.0.0, which replaces the built-in `Uuid` with the [uuid](https://pub.dev/packages/uuid) package
+
 ## 2.0.1
 
 * register the 1.x `LocationService`, `WeatherService`, and `AirQualityService` device types as `fromJson` aliases, for backwards compatibility with studies created on CAMS 1.x (protocol API level < 2.0)

--- a/packages/carp_context_package/pubspec.yaml
+++ b/packages/carp_context_package/pubspec.yaml
@@ -1,5 +1,5 @@
 name: carp_context_package
-version: 2.0.3
+version: 2.1.0
 description: CARP context sampling package. Samples location, mobility, activity, weather, air-quality, and geofence.
 homepage: https://github.com/cph-cachet/carp.sensing-flutter
 repository: https://github.com/cph-cachet/carp.sensing-flutter/tree/main/packages/carp_context_package
@@ -25,8 +25,8 @@ dependencies:
     sdk: flutter
  
   carp_serializable: ^3.0.0
-  carp_core: ^2.0.0
-  carp_mobile_sensing: ^2.0.0
+  carp_core: ^2.2.0
+  carp_mobile_sensing: ^2.2.0
  
   json_annotation: ^4.8.0
   permission_handler: '>=11.0.0 <13.0.0'

--- a/packages/carp_esense_package/CHANGELOG.md
+++ b/packages/carp_esense_package/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.0
+
+* require `carp_serializable` ^3.0.0, which replaces the built-in `Uuid` with the [uuid](https://pub.dev/packages/uuid) package
+
 ## 2.0.1
 
 * register the 1.x `ESenseDevice` device type as a `fromJson` alias, for backwards compatibility with studies created on CAMS 1.x (protocol API level < 2.0)

--- a/packages/carp_esense_package/pubspec.yaml
+++ b/packages/carp_esense_package/pubspec.yaml
@@ -1,5 +1,5 @@
 name: carp_esense_package
-version: 2.0.1
+version: 2.1.0
 description: The CARP eSense sampling package. Samples sensor and device events from the eSense ear plug device.
 homepage: https://github.com/cph-cachet/carp.sensing-flutter
 repository: https://github.com/cph-cachet/carp.sensing-flutter/tree/main/packages/carp_esense_package
@@ -25,8 +25,8 @@ dependencies:
     sdk: flutter
 
   carp_serializable: ^3.0.0
-  carp_core: ^2.0.0
-  carp_mobile_sensing: ^2.0.0
+  carp_core: ^2.2.0
+  carp_mobile_sensing: ^2.2.0
  
   json_annotation: ^4.8.0
   esense_flutter: ^1.0.0

--- a/packages/carp_health_package/CHANGELOG.md
+++ b/packages/carp_health_package/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.1.0
+
+* require `carp_serializable` ^3.0.0, which replaces the built-in `Uuid` with the [uuid](https://pub.dev/packages/uuid) package
+
 ## 4.0.1
 
 * register the 1.x `HealthService` device type as a `fromJson` alias, for backwards compatibility with studies created on CAMS 1.x (protocol API level < 2.0)

--- a/packages/carp_health_package/pubspec.yaml
+++ b/packages/carp_health_package/pubspec.yaml
@@ -1,5 +1,5 @@
 name: carp_health_package
-version: 4.0.3
+version: 4.1.0
 description: CARP health sampling package. Samples health data from Apple Health or Google Fit.
 homepage: https://github.com/cph-cachet/carp.sensing-flutter
 repository: https://github.com/cph-cachet/carp.sensing-flutter/tree/main/packages/carp_health_package
@@ -25,8 +25,8 @@ dependencies:
     sdk: flutter
 
   carp_serializable: ^3.0.0
-  carp_core: ^2.0.0
-  carp_mobile_sensing: ^2.0.0
+  carp_core: ^2.2.0
+  carp_mobile_sensing: ^2.2.0
 
   json_annotation: ^4.8.0
   health: ^13.3.1

--- a/packages/carp_movesense_package/CHANGELOG.md
+++ b/packages/carp_movesense_package/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.1.0
+
+* require `carp_serializable` ^3.0.0, which replaces the built-in `Uuid` with the [uuid](https://pub.dev/packages/uuid) package
+
 ## 3.0.1
 
 * default `namePrefix` to `'Movesense'` (mirroring `PolarDevice`), so BLE scan filtering works for Movesense devices deployed from CAWS without an explicit prefix

--- a/packages/carp_movesense_package/pubspec.yaml
+++ b/packages/carp_movesense_package/pubspec.yaml
@@ -1,5 +1,5 @@
 name: carp_movesense_package
-version: 3.0.1
+version: 3.1.0
 description: The CARP Movesense sampling package. Samples sensor data from the Movesense MD and ACTIVE (HR+, HR2) devices.
 homepage: https://github.com/cph-cachet/carp.sensing-flutter
 repository: https://github.com/cph-cachet/carp.sensing-flutter/tree/main/packages/carp_movesense_package
@@ -26,8 +26,8 @@ dependencies:
     sdk: flutter
 
   carp_serializable: ^3.0.0 # polymorphic json serialization
-  carp_core: ^2.0.0         # the core CARP domain model
-  carp_mobile_sensing: ^2.0.0
+  carp_core: ^2.2.0         # the core CARP domain model
+  carp_mobile_sensing: ^2.2.0
 
   carp_movesense_flutter: ^0.1.0
   json_annotation: ^4.8.0

--- a/packages/carp_movisens_package/CHANGELOG.md
+++ b/packages/carp_movisens_package/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.0
+
+* require `carp_serializable` ^3.0.0, which replaces the built-in `Uuid` with the [uuid](https://pub.dev/packages/uuid) package
+
 ## 2.0.1
 
 * register the 1.x `MovisensDevice` device type as a `fromJson` alias, for backwards compatibility with studies created on CAMS 1.x (protocol API level < 2.0)

--- a/packages/carp_movisens_package/pubspec.yaml
+++ b/packages/carp_movisens_package/pubspec.yaml
@@ -1,5 +1,5 @@
 name: carp_movisens_package
-version: 2.0.1
+version: 2.1.0
 description: CARP Movisens sampling package. Samples movement, activity, HRV, MET-level, and ECG for the Movisens Move4 and EcgMove4 devices
 homepage: https://github.com/cph-cachet/carp.sensing-flutter
 repository: https://github.com/cph-cachet/carp.sensing-flutter/tree/main/packages/carp_movisens_package
@@ -25,8 +25,8 @@ dependencies:
     sdk: flutter
 
   carp_serializable: ^3.0.0
-  carp_core: ^2.0.0
-  carp_mobile_sensing: ^2.0.0
+  carp_core: ^2.2.0
+  carp_mobile_sensing: ^2.2.0
  
   json_annotation: ^4.8.0
   async: ^2.7.0

--- a/packages/carp_polar_package/CHANGELOG.md
+++ b/packages/carp_polar_package/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.0
+
+* require `carp_serializable` ^3.0.0, which replaces the built-in `Uuid` with the [uuid](https://pub.dev/packages/uuid) package
+
 ## 2.0.2
 
 * discover data types from both the online streaming (PMD) and the HR service SDK features, so devices that only deliver HR via the standard BLE HR service (e.g. Verity Sense) report their supported types

--- a/packages/carp_polar_package/pubspec.yaml
+++ b/packages/carp_polar_package/pubspec.yaml
@@ -1,5 +1,5 @@
 name: carp_polar_package
-version: 2.0.2
+version: 2.1.0
 description: The CARP Polar sampling package. Samples sensor data from the Polar H9, H10, and Verity Sense devices.
 homepage: https://github.com/cph-cachet/carp.sensing-flutter
 repository: https://github.com/cph-cachet/carp.sensing-flutter/tree/main/packages/carp_polar_package
@@ -25,8 +25,8 @@ dependencies:
     sdk: flutter
 
   carp_serializable: ^3.0.0
-  carp_core: ^2.0.0
-  carp_mobile_sensing: ^2.0.0
+  carp_core: ^2.2.0
+  carp_mobile_sensing: ^2.2.0
  
   json_annotation: ^4.8.0
   polar: ^7.0.0

--- a/packages/carp_survey_package/CHANGELOG.md
+++ b/packages/carp_survey_package/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.0
+
+* require `carp_serializable` ^3.0.0, which replaces the built-in `Uuid` with the [uuid](https://pub.dev/packages/uuid) package
+
 ## 2.0.1
 
 * upgrade to `carp_mobile_sensing` v. 2.1.3

--- a/packages/carp_survey_package/pubspec.yaml
+++ b/packages/carp_survey_package/pubspec.yaml
@@ -1,5 +1,5 @@
 name: carp_survey_package
-version: 2.0.1
+version: 2.1.0
 description: CARP survey sampling package. Samples survey data from the CARP Research Package and Cognition Package.
 homepage: https://github.com/cph-cachet/carp.sensing-flutter
 repository: https://github.com/cph-cachet/carp.sensing-flutter/tree/master/packages/carp_survey_package
@@ -25,8 +25,8 @@ dependencies:
     sdk: flutter
 
   carp_serializable: ^3.0.0
-  carp_core: ^2.0.0
-  carp_mobile_sensing: ^2.1.3
+  carp_core: ^2.2.0
+  carp_mobile_sensing: ^2.2.0
 
   research_package: ^2.0.0
   cognition_package: ^1.6.0

--- a/publish.sh
+++ b/publish.sh
@@ -67,4 +67,4 @@ for dir in "${pending[@]}"; do
     is_published "$name" "$version" && break
     sleep 5
   done
-done 
+done

--- a/publish.sh
+++ b/publish.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Publish packages whose local version is not on pub.dev yet, dependencies first.
+# Usage: ./publish.sh [--publish]
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+# Dependencies first: a package can only be published once what it depends on is live.
+PACKAGES=(
+  carp_serializable
+  carp_core
+  carp_mobile_sensing
+  packages/carp_apps_package
+  packages/carp_audio_package
+  packages/carp_communication_package
+  packages/carp_connectivity_package
+  packages/carp_context_package
+  packages/carp_esense_package
+  packages/carp_health_package
+  packages/carp_movesense_package
+  packages/carp_movisens_package
+  packages/carp_polar_package
+  packages/carp_survey_package
+  backends/carp_webservices
+  backends/carp_backend
+  utilities/carp_study_generator
+)
+
+version_of() { sed -n 's/^version: *//p' "$1/pubspec.yaml" | head -1; }
+name_of() { sed -n 's/^name: *//p' "$1/pubspec.yaml" | head -1; }
+
+is_published() { # name version
+  curl -sf "https://pub.dev/api/packages/$1" | grep -q "\"version\":\"$2\""
+}
+
+pending=()
+for dir in "${PACKAGES[@]}"; do
+  name=$(name_of "$dir")
+  version=$(version_of "$dir")
+  if is_published "$name" "$version"; then
+    printf '  %-28s %-8s already published\n' "$name" "$version"
+  else
+    printf '* %-28s %-8s to publish\n' "$name" "$version"
+    pending+=("$dir")
+  fi
+done
+
+[ ${#pending[@]} -eq 0 ] && { echo "Nothing to publish."; exit 0; }
+
+if [ "${1:-}" != "--publish" ]; then
+  echo
+  echo "Re-run with --publish to publish the ${#pending[@]} package(s) above."
+  exit 0
+fi
+
+[ -n "$(git status --porcelain)" ] && { echo "Worktree is dirty."; exit 1; }
+
+# Validate everything first - publishing is irreversible, so no partial releases.
+for dir in "${pending[@]}"; do
+  echo "== validating $(name_of "$dir")"
+  (cd "$dir" && dart pub publish --dry-run)
+done
+
+for dir in "${pending[@]}"; do
+  name=$(name_of "$dir")
+  version=$(version_of "$dir")
+  echo "== publishing $name $version"
+  (cd "$dir" && dart pub publish --force)
+
+  # Wait for pub.dev to serve it, so the next package can resolve it.
+  for _ in $(seq 60); do
+    is_published "$name" "$version" && break
+    sleep 5
+  done
+done

--- a/publish.sh
+++ b/publish.sh
@@ -23,7 +23,6 @@ PACKAGES=(
   packages/carp_survey_package
   backends/carp_webservices
   backends/carp_backend
-  utilities/carp_study_generator
 )
 
 version_of() { sed -n 's/^version: *//p' "$1/pubspec.yaml" | head -1; }
@@ -68,4 +67,4 @@ for dir in "${pending[@]}"; do
     is_published "$name" "$version" && break
     sleep 5
   done
-done
+done 

--- a/publish.sh
+++ b/publish.sh
@@ -55,12 +55,8 @@ fi
 
 [ -n "$(git status --porcelain)" ] && { echo "Worktree is dirty."; exit 1; }
 
-# Validate everything first - publishing is irreversible, so no partial releases.
-for dir in "${pending[@]}"; do
-  echo "== validating $(name_of "$dir")"
-  (cd "$dir" && dart pub publish --dry-run)
-done
-
+# ponytail: no upfront validation of all packages - a dependent cannot resolve until
+# its dependency is live. On failure, re-run: published packages are skipped.
 for dir in "${pending[@]}"; do
   name=$(name_of "$dir")
   version=$(version_of "$dir")

--- a/utilities/carp_study_generator/CHANGELOG.md
+++ b/utilities/carp_study_generator/CHANGELOG.md
@@ -1,7 +1,3 @@
-## 2.1.0
-
-* require `carp_serializable` ^3.0.0, which replaces the built-in `Uuid` with the [uuid](https://pub.dev/packages/uuid) package
-
 ## 2.0.0
 
 * upgrade to CARP Core and CAMS API level 2.0.0

--- a/utilities/carp_study_generator/CHANGELOG.md
+++ b/utilities/carp_study_generator/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.0
+
+* require `carp_serializable` ^3.0.0, which replaces the built-in `Uuid` with the [uuid](https://pub.dev/packages/uuid) package
+
 ## 2.0.0
 
 * upgrade to CARP Core and CAMS API level 2.0.0

--- a/utilities/carp_study_generator/pubspec.yaml
+++ b/utilities/carp_study_generator/pubspec.yaml
@@ -1,5 +1,5 @@
 name: carp_study_generator
-version: 2.1.0
+version: 2.0.0
 description: Utilities for managing CARP Mobile Sensing studies, including generating and uploading a study protocol, informed consent, translations, and messages.
 homepage: https://github.com/cph-cachet/carp.sensing-flutter
 repository: https://github.com/cph-cachet/carp.sensing-flutter/tree/main/utilities/carp_study_generator
@@ -20,10 +20,10 @@ dependencies:
     sdk: flutter
 
   carp_serializable: ^3.0.0
-  carp_core: ^2.2.0
-  carp_mobile_sensing: ^2.2.0
-  carp_webservices: ^4.2.0
-  carp_backend: ^2.1.0
+  carp_core: ^2.0.0
+  carp_mobile_sensing: ^2.0.0
+  carp_webservices: ^4.0.0
+  carp_backend: ^2.0.0
   carp_apps_package: ^2.0.0
   carp_context_package: ^2.0.0
   carp_audio_package: ^2.0.0

--- a/utilities/carp_study_generator/pubspec.yaml
+++ b/utilities/carp_study_generator/pubspec.yaml
@@ -1,5 +1,5 @@
 name: carp_study_generator
-version: 2.0.0
+version: 2.1.0
 description: Utilities for managing CARP Mobile Sensing studies, including generating and uploading a study protocol, informed consent, translations, and messages.
 homepage: https://github.com/cph-cachet/carp.sensing-flutter
 repository: https://github.com/cph-cachet/carp.sensing-flutter/tree/main/utilities/carp_study_generator
@@ -20,10 +20,10 @@ dependencies:
     sdk: flutter
 
   carp_serializable: ^3.0.0
-  carp_core: ^2.0.0
-  carp_mobile_sensing: ^2.0.0
-  carp_webservices: ^4.0.0
-  carp_backend: ^2.0.0
+  carp_core: ^2.2.0
+  carp_mobile_sensing: ^2.2.0
+  carp_webservices: ^4.2.0
+  carp_backend: ^2.1.0
   carp_apps_package: ^2.0.0
   carp_context_package: ^2.0.0
   carp_audio_package: ^2.0.0


### PR DESCRIPTION
## Summary

Follow-up to the `carp_serializable` 3.0.0 release (uuid-package migration, #601). Bumps every dependent package so they require `carp_serializable` ^3.0.0, and raises the inter-package constraints so pub can't resolve back to a `carp_serializable` 2.x transitive.

### Version bumps

| package | old -> new |
|---|---|
| carp_core | 2.1.2 -> **2.2.0** |
| carp_mobile_sensing | 2.1.8 -> **2.2.0** |
| carp_webservices | 4.1.1 -> **4.2.0** |
| carp_backend | 2.0.1 -> **2.1.0** |
| carp_study_generator | 2.0.0 -> **2.1.0** |
| carp_health_package | 4.0.3 -> **4.1.0** |
| carp_movesense_package | 3.0.1 -> **3.1.0** |
| the 8 other `*_package`s | 2.0.x -> **2.1.0** |

### Constraint raises
`carp_core ^2.2.0`, `carp_mobile_sensing ^2.2.0`, `carp_webservices ^4.2.0`, `carp_backend ^2.1.0` everywhere they're depended on.

### Notes
- Each package gets a matching CHANGELOG entry.
- `carp_firebase_backend` (pinned to the 0.30 line) is intentionally untouched.
- All `Uuid().v1` call sites were already migrated to `const Uuid().v4()` — no code changes needed here, only pubspec/CHANGELOG.
