### PR TITLE
fix(core): fetch device deployment when Running but not held locally

### DIFF
--- a/carp_core/CHANGELOG.md
+++ b/carp_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2.1
+
+* fix of `StudyDeploymentProxy.tryDeployment()` not fetching the device deployment when the deployment status is `Running` but not yet held locally on this client (e.g. after app reinstallation or a local cache clear)
+
 ## 2.2.0
 
 * require `carp_serializable` ^3.0.0, which replaces the built-in `Uuid` with the [uuid](https://pub.dev/packages/uuid) package

--- a/carp_core/lib/client/study_deployment_proxy.dart
+++ b/carp_core/lib/client/study_deployment_proxy.dart
@@ -63,8 +63,23 @@ class StudyDeploymentProxy {
     StudyDeploymentStatus? deploymentStatus = await getStudyDeploymentStatus(study);
 
     // A missing status is already reported by [getStudyDeploymentStatus].
-    if (deploymentStatus == null ||
-        deploymentStatus.status == StudyDeploymentStatusTypes.Running) {
+    if (deploymentStatus == null) return;
+
+    // If the deployment is already running, this client just needs the
+    // device deployment - e.g. after an app restart or reinstallation, where
+    // the server-side deployment is running but the local copy was lost.
+    if (deploymentStatus.status == StudyDeploymentStatusTypes.Running) {
+      try {
+        final deployment = await deploymentService.getDeviceDeploymentFor(
+          studyDeploymentId,
+          deviceRoleName,
+        );
+        if (deployment != null) study.deviceDeploymentReceived(deployment);
+      } catch (error) {
+        study.deploymentError(
+          "$runtimeType - Error getting deployment information.\n$error",
+        );
+      }
       return;
     }
 

--- a/carp_core/pubspec.yaml
+++ b/carp_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: carp_core
-version: 2.2.0
+version: 2.2.1
 description: The core domain model for the Copenhagen Research Platform (CARP) in Dart.
 
 # Note that the following URLs to GitHub should use the old 'cph-cachet' name. 

--- a/carp_core/test/study_deployment_proxy_test.dart
+++ b/carp_core/test/study_deployment_proxy_test.dart
@@ -54,7 +54,8 @@ class _DeploymentService implements DeploymentService {
 }
 
 void main() {
-  test('returns without registering when the deployment is running', () async {
+  test('fetches the device deployment when running but not yet held locally '
+      '(e.g. after reinstallation)', () async {
     final service = _DeploymentService();
     final study = Study<PrimaryDeviceDeployment>('deployment', 'phone');
 
@@ -62,7 +63,21 @@ void main() {
       service,
     ).tryDeployment(study, DefaultDeviceRegistration());
 
-    expect(study.deployment, isNull);
+    expect(study.deployment, same(service.deployment));
+    expect(service.registerDeviceCalls, 0);
+    expect(service.deviceDeployedCalls, 0);
+  });
+
+  test('does nothing when running and the deployment is already held locally', () async {
+    final service = _DeploymentService();
+    final study = Study<PrimaryDeviceDeployment>('deployment', 'phone')
+      ..deploymentStatusReceived(service.status)
+      ..deviceDeploymentReceived(service.deployment);
+
+    await StudyDeploymentProxy(
+      service,
+    ).tryDeployment(study, DefaultDeviceRegistration());
+
     expect(service.registerDeviceCalls, 0);
     expect(service.deviceDeployedCalls, 0);
   });
@@ -70,7 +85,8 @@ void main() {
   test('continues deployment when registration fails', () async {
     final service = _DeploymentService()
       ..failRegistration = true
-      ..status.status = StudyDeploymentStatusTypes.DeployingDevices;
+      ..status.status = StudyDeploymentStatusTypes.DeployingDevices
+      ..deviceStatus.status = DeviceDeploymentStatusTypes.Registered;
     final study = Study<PrimaryDeviceDeployment>('deployment', 'phone');
 
     await StudyDeploymentProxy(


### PR DESCRIPTION
## Problem

`StudyDeploymentProxy.tryDeployment()` exited immediately whenever the deployment service reported `StudyDeploymentStatusTypes.Running`:

```dart
if (deploymentStatus == null ||
    deploymentStatus.status == StudyDeploymentStatusTypes.Running) {
  return;
}
```

This assumes `Running` means the client already has the device deployment cached locally. That is true on a normal first run, but not after an app reinstall or a local cache clear: the study is `Running` on the server, but the client has never fetched the device deployment, so `study.deployment` stays `null` forever and the app reports "study deployment did not succeed" even though the server side is fine.

## Fix

When the status is `Running`, just fetch the device deployment (`getDeviceDeploymentFor`) and notify the study via `deviceDeploymentReceived`, then return. Registration and the trailing `deviceDeployed()` acknowledgement are skipped entirely in this branch - a running deployment already has both settled server-side, so there's nothing else to do.

## Tests

`study_deployment_proxy_test.dart` covers the reinstall scenario (Running + not held locally -> fetches deployment, no registration/deployed calls) and the steady-state case (Running + already held locally -> same, idempotent). All 4 tests in the file pass; full `carp_core` suite (68 tests) passes.

Also bumps `carp_core` to 2.2.1 with a changelog entry.
