### PR TITLE
fix(cams): only add the record_id column/index when not already present

### DIFF
--- a/carp_mobile_sensing/CHANGELOG.md
+++ b/carp_mobile_sensing/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.3.1
+
+* fix `duplicate column name: record_id` crash in the `record_id` SQLite migration (`SQLiteDataManager.onUpgrade`) by only adding the column/index when it isn't already there
+
 ## 2.3.0
 
 * upgrade to `device_info_plus` ^13.2.0 and `package_info_plus` ^10.2.1, which require Flutter >=3.38.1

--- a/carp_mobile_sensing/lib/infrastructure/data_managers/sqlite_data_manager.dart
+++ b/carp_mobile_sensing/lib/infrastructure/data_managers/sqlite_data_manager.dart
@@ -96,12 +96,22 @@ class SQLiteDataManager extends AbstractDataManager {
       },
       onUpgrade: (Database db, int oldVersion, int newVersion) async {
         if (oldVersion < 2) {
-          await db.execute(
-            'ALTER TABLE $MEASUREMENT_TABLE_NAME '
-            'ADD COLUMN $RECORD_ID_COLUMN TEXT',
+          // The column/index may already exist, so guard both statements
+          // instead of crashing the upgrade on "already exists".
+          final columns = await db.rawQuery(
+            'PRAGMA table_info($MEASUREMENT_TABLE_NAME)',
           );
+          final hasRecordIdColumn = columns.any(
+            (column) => column['name'] == RECORD_ID_COLUMN,
+          );
+          if (!hasRecordIdColumn) {
+            await db.execute(
+              'ALTER TABLE $MEASUREMENT_TABLE_NAME '
+              'ADD COLUMN $RECORD_ID_COLUMN TEXT',
+            );
+          }
           await db.execute(
-            'CREATE UNIQUE INDEX measurements_record_id '
+            'CREATE UNIQUE INDEX IF NOT EXISTS measurements_record_id '
             'ON $MEASUREMENT_TABLE_NAME('
             '$DEPLOYMENT_ID_COLUMN, $DEVICE_ROLE_NAME_COLUMN, '
             '$RECORD_ID_COLUMN)',

--- a/carp_mobile_sensing/pubspec.yaml
+++ b/carp_mobile_sensing/pubspec.yaml
@@ -1,5 +1,5 @@
 name: carp_mobile_sensing
-version: 2.3.0
+version: 2.3.1
 description: Mobile Sensing Framework for Flutter. A software framework for collecting sensor data from the phone and attached wearable devices via probes. Can be extended.
 
 # Note that the following URLs to GitHub should use the old 'cph-cachet' name.

--- a/carp_mobile_sensing/test/sqlite_record_deduplication_test.dart
+++ b/carp_mobile_sensing/test/sqlite_record_deduplication_test.dart
@@ -85,6 +85,40 @@ void main() {
 
     await manager.database?.close();
   });
+
+  test('re-upgrades a database stuck with the column but no version bump', () async {
+    // A v1 database that already has the record_id column used to crash the
+    // upgrade with "duplicate column name: record_id".
+    final path = await _databasePath();
+    await deleteDatabase(path);
+    final legacy = await openDatabase(
+      path,
+      version: 1,
+      onCreate: (database, _) => database.execute(
+        'CREATE TABLE ${SQLiteDataManager.MEASUREMENT_TABLE_NAME} ('
+        '${SQLiteDataManager.ID_COLUMN} INTEGER PRIMARY KEY, '
+        '${SQLiteDataManager.DEPLOYMENT_ID_COLUMN} TEXT, '
+        '${SQLiteDataManager.DEVICE_ROLE_NAME_COLUMN} TEXT, '
+        '${SQLiteDataManager.DATATYPE_COLUMN} TEXT)',
+      ),
+    );
+    await legacy.execute(
+      'ALTER TABLE ${SQLiteDataManager.MEASUREMENT_TABLE_NAME} '
+      'ADD COLUMN ${SQLiteDataManager.RECORD_ID_COLUMN} TEXT',
+    );
+    await legacy.insert(SQLiteDataManager.MEASUREMENT_TABLE_NAME, {
+      SQLiteDataManager.DEPLOYMENT_ID_COLUMN: 'study-a',
+    });
+    await legacy.close();
+
+    final manager = await _manager(reset: false);
+    expect(
+      await manager.database!.query(SQLiteDataManager.MEASUREMENT_TABLE_NAME),
+      hasLength(1),
+    );
+
+    await manager.database?.close();
+  });
 }
 
 Future<SQLiteDataManager> _manager({bool reset = true}) async {


### PR DESCRIPTION
## Problem

Seen on a device during the `record_id` migration:

```
DatabaseException(duplicate column name: record_id (code 1 SQLITE_ERROR[1]): , while compiling: ALTER TABLE measurements ADD COLUMN record_id TEXT)
```

The upgrade tried to add the `record_id` column to `measurements` when it was already there, and crashed on every launch.

## Fix

Make the migration statements safe to re-run from now on:
- check `PRAGMA table_info(measurements)` for the column before `ALTER TABLE ADD COLUMN`
- use `CREATE UNIQUE INDEX IF NOT EXISTS` for the index

## Tests

Added `re-upgrades a database stuck with the column but no version bump`, which reproduces the state (column already present, `user_version` still `1`) and asserts the upgrade completes without throwing. All tests in `sqlite_record_deduplication_test.dart` pass (4/4).

Note: `data_manager_test.dart`'s `a closed data manager stops writing measurements` and `sqlite_record_deduplication_test.dart`'s `ignores duplicate source records` are pre-existing order-dependent flaky failures when the full suite runs together - reproducible on `main` without this change, unrelated to this fix.
