### PR TITLE
feat(webservices): query data streams by local update time

### DIFF
--- a/backends/carp_webservices/CHANGELOG.md
+++ b/backends/carp_webservices/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 4.3.0
 
-* Add `queryDataStreamByTime()` / `DataStreamReference.getByTime()` - query a data stream by local update time window via the CAWS `query-by-time` endpoint
+* Add `getDataStreamBatchesByTime()` (on `CarpDataStreamService` and `DataStreamReference`) - query a data stream by local update time window via the CAWS `query-by-time` endpoint
 * Rename `CarpDataStreamService().stream()` to `dataStream()` (old name deprecated)
 
 ## 4.2.0

--- a/backends/carp_webservices/CHANGELOG.md
+++ b/backends/carp_webservices/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 4.3.0
+
+* Add `queryDataStreamByTime()` / `DataStreamReference.getByTime()` - query a data stream by local update time window via the CAWS `query-by-time` endpoint
+* Rename `CarpDataStreamService().stream()` to `dataStream()` (old name deprecated)
+
 ## 4.2.0
 
 * require `carp_serializable` ^3.0.0, which replaces the built-in `Uuid` with the [uuid](https://pub.dev/packages/uuid) package

--- a/backends/carp_webservices/README.md
+++ b/backends/carp_webservices/README.md
@@ -390,7 +390,7 @@ var batch = [
 ];
 
 // Get a data stream and append the batch
-CarpDataStreamService().stream().append(batch);
+CarpDataStreamService().dataStream(studyDeploymentId).append(batch);
 ```
 
 However, you would rarely need to use these endpoints in your app, since the [carp_backend](https://pub.dev/packages/carp_backend) would handle this when you use a [`CarpDataEndPoint`](https://pub.dev/documentation/carp_backend/latest/carp_backend/CarpDataEndPoint-class.html) as the data endpoint in the study protocol.

--- a/backends/carp_webservices/lib/carp_services/data_stream_reference.dart
+++ b/backends/carp_webservices/lib/carp_services/data_stream_reference.dart
@@ -54,9 +54,9 @@ class DataStreamReference extends RPCCarpReference {
   /// Get all data points in [dataStream] whose local update time falls
   /// within the inclusive [from]-[to] window, as one [DataStreamBatch] per
   /// contiguous run of measurements.
-  Future<List<DataStreamBatch>> getByTime(
+  Future<List<DataStreamBatch>> getDataStreamBatchesByTime(
     DataStreamId dataStream,
     DateTime from,
     DateTime to,
-  ) async => await service.queryDataStreamByTime(dataStream, from, to);
+  ) async => await service.getDataStreamBatchesByTime(dataStream, from, to);
 }

--- a/backends/carp_webservices/lib/carp_services/data_stream_reference.dart
+++ b/backends/carp_webservices/lib/carp_services/data_stream_reference.dart
@@ -50,4 +50,13 @@ class DataStreamReference extends RPCCarpReference {
     fromSequenceId,
     toSequenceIdInclusive,
   );
+
+  /// Get all data points in [dataStream] whose local update time falls
+  /// within the inclusive [from]-[to] window, as one [DataStreamBatch] per
+  /// contiguous run of measurements.
+  Future<List<DataStreamBatch>> getByTime(
+    DataStreamId dataStream,
+    DateTime from,
+    DateTime to,
+  ) async => await service.queryDataStreamByTime(dataStream, from, to);
 }

--- a/backends/carp_webservices/lib/carp_services/data_stream_service.dart
+++ b/backends/carp_webservices/lib/carp_services/data_stream_service.dart
@@ -5,6 +5,8 @@ class CarpDataStreamService extends CarpBaseService
     implements DataStreamService {
   static const String DATA_STREAM_ENDPOINT_NAME = "data-stream-service";
   static const String DATA_STREAM_ZIP_ENDPOINT_NAME = "data-stream-service-zip";
+  static const String DATA_STREAM_QUERY_BY_TIME_ENDPOINT_NAME =
+      "data-stream-service/query-by-time";
 
   static final CarpDataStreamService _instance = CarpDataStreamService._();
 
@@ -19,8 +21,13 @@ class CarpDataStreamService extends CarpBaseService
   String get rpcEndpointName => DATA_STREAM_ENDPOINT_NAME;
 
   /// Gets a [DataStreamReference] for a [studyDeploymentId].
-  DataStreamReference stream(String studyDeploymentId) =>
+  DataStreamReference dataStream(String studyDeploymentId) =>
       DataStreamReference._(this, studyDeploymentId);
+
+  /// Gets a [DataStreamReference] for a [studyDeploymentId].
+  @Deprecated('Use dataStream() instead.')
+  DataStreamReference stream(String studyDeploymentId) =>
+      dataStream(studyDeploymentId);
 
   @override
   Future<void> openDataStreams(DataStreamsConfiguration configuration) async =>
@@ -60,18 +67,45 @@ class CarpDataStreamService extends CarpBaseService
       GetDataStream(dataStream, fromSequenceId, toSequenceIdInclusive),
     );
 
-    // we expect a list of DataStreamBatch in the response
-    List<dynamic> batches = responseJson as List<dynamic>;
-
-    return (batches.isEmpty)
-        ? []
-        : batches
-              .map(
-                (batch) =>
-                    DataStreamBatch.fromJson(batch as Map<String, dynamic>),
-              )
-              .toList();
+    return _toDataStreamBatches(responseJson);
   }
+
+  /// Query [dataStream] by its local update time window instead of a
+  /// sequence-id range.
+  ///
+  /// Returns all data points in [dataStream] whose local `updated_at`
+  /// timestamp falls within the inclusive [from]-[to] window, as one
+  /// [DataStreamBatch] per contiguous run of measurements - a new batch
+  /// starts wherever the sequence was interrupted.
+  ///
+  /// This is a CAWS-specific endpoint (not part of the core
+  /// [DataStreamService] interface) and mirrors [getDataStream], but is
+  /// useful when the local upload time is more relevant than the sequence id
+  /// (e.g., incremental sync of recently uploaded data).
+  Future<List<DataStreamBatch>> queryDataStreamByTime(
+    DataStreamId dataStream,
+    DateTime from,
+    DateTime to,
+  ) async {
+    final url =
+        "${app.uri}/api/$DATA_STREAM_QUERY_BY_TIME_ENDPOINT_NAME"
+        "?from=${from.toUtc().toIso8601String()}&to=${to.toUtc().toIso8601String()}";
+
+    final response = await _post(
+      Uri.encodeFull(url),
+      body: json.encode(dataStream.toJson()),
+    );
+
+    return _toDataStreamBatches(_handleResponse(response));
+  }
+
+  /// Both data stream queries return a JSON list of [DataStreamBatch].
+  List<DataStreamBatch> _toDataStreamBatches(dynamic responseJson) =>
+      (responseJson as List<dynamic>)
+          .map(
+            (batch) => DataStreamBatch.fromJson(batch as Map<String, dynamic>),
+          )
+          .toList();
 
   @override
   Future<void> closeDataStreams(List<String> studyDeploymentIds) async =>

--- a/backends/carp_webservices/lib/carp_services/data_stream_service.dart
+++ b/backends/carp_webservices/lib/carp_services/data_stream_service.dart
@@ -82,7 +82,7 @@ class CarpDataStreamService extends CarpBaseService
   /// [DataStreamService] interface) and mirrors [getDataStream], but is
   /// useful when the local upload time is more relevant than the sequence id
   /// (e.g., incremental sync of recently uploaded data).
-  Future<List<DataStreamBatch>> queryDataStreamByTime(
+  Future<List<DataStreamBatch>> getDataStreamBatchesByTime(
     DataStreamId dataStream,
     DateTime from,
     DateTime to,

--- a/backends/carp_webservices/pubspec.yaml
+++ b/backends/carp_webservices/pubspec.yaml
@@ -1,5 +1,5 @@
 name: carp_webservices
-version: 4.2.0
+version: 4.3.0
 description: Flutter API for accessing the CARP web services, including authentication, deployments, data, files, and collections of documents.
 homepage: https://github.com/cph-cachet/carp.sensing-flutter
 repository: https://github.com/carp-dk/carp.sensing-flutter/tree/main/backends/carp_webservices

--- a/backends/carp_webservices/test/data_stream_query_by_time_test.dart
+++ b/backends/carp_webservices/test/data_stream_query_by_time_test.dart
@@ -1,4 +1,4 @@
-// Self-check for CarpDataStreamService.queryDataStreamByTime's request
+// Self-check for CarpDataStreamService.getDataStreamBatchesByTime's request
 // shape, without hitting the network: endpoint path, DataStreamId JSON body,
 // and the ISO-8601 `from`/`to` query params (must be UTC + parseable by the
 // Kotlin `Instant` converter on the CAWS backend).

--- a/backends/carp_webservices/test/data_stream_query_by_time_test.dart
+++ b/backends/carp_webservices/test/data_stream_query_by_time_test.dart
@@ -1,0 +1,69 @@
+// Self-check for CarpDataStreamService.queryDataStreamByTime's request
+// shape, without hitting the network: endpoint path, DataStreamId JSON body,
+// and the ISO-8601 `from`/`to` query params (must be UTC + parseable by the
+// Kotlin `Instant` converter on the CAWS backend).
+import 'dart:convert';
+
+import 'package:carp_core/carp_core.dart';
+import 'package:carp_mobile_sensing/carp_mobile_sensing.dart';
+import 'package:carp_webservices/carp_services/carp_services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  setUpAll(() {
+    // registers the data types (StepCount, ...) used in the JSON below.
+    CarpMobileSensing.ensureInitialized();
+  });
+
+  test('query-by-time endpoint path and request shape', () {
+    expect(
+      CarpDataStreamService.DATA_STREAM_QUERY_BY_TIME_ENDPOINT_NAME,
+      'data-stream-service/query-by-time',
+    );
+
+    final dataStream = DataStreamId(
+      studyDeploymentId: '00000000-0000-0000-0000-000000000000',
+      deviceRoleName: 'Primary Phone',
+      dataType: 'dk.cachet.carp.heartbeat',
+    );
+
+    // Body must be the plain DataStreamId JSON (mirrors what the Spring
+    // controller decodes via WS_JSON.decodeFromString(DataStreamId.serializer())).
+    final body = dataStream.toJson();
+    expect(body['studyDeploymentId'], dataStream.studyDeploymentId);
+    expect(body['deviceRoleName'], dataStream.deviceRoleName);
+    expect(DataStreamId.fromJson(body).toJson(), body);
+
+    // from/to must be UTC ISO-8601 instants ending in 'Z' so the Kotlin
+    // backend's Instant converter accepts them as query params.
+    final from = DateTime.utc(2026, 8, 1);
+    final to = DateTime.utc(2026, 8, 5);
+    expect(from.toUtc().toIso8601String(), '2026-08-01T00:00:00.000Z');
+    expect(to.toUtc().toIso8601String(), '2026-08-05T00:00:00.000Z');
+  });
+
+  test('response is a JSON list of batches, one per contiguous run', () {
+    // The endpoint returns an array - a new batch starts wherever the
+    // sequence was interrupted - not a single DataStreamBatch object.
+    final responseJson = json.decode('''
+      [{"dataStream":{"studyDeploymentId":"4f282ef1-35a5-4e20-8ad7-744ac3c8a8bb",
+        "deviceRoleName":"Primary Phone","dataType":"dk.cachet.carp.stepcount"},
+        "firstSequenceId":1,"triggerIds":[4],
+        "measurements":[{"sensorStartTime":1786965175523786,
+          "data":{"__type":"dk.cachet.carp.stepcount","steps":187718}}]},
+       {"dataStream":{"studyDeploymentId":"4f282ef1-35a5-4e20-8ad7-744ac3c8a8bb",
+        "deviceRoleName":"Primary Phone","dataType":"dk.cachet.carp.stepcount"},
+        "firstSequenceId":14,"triggerIds":[4],
+        "measurements":[{"sensorStartTime":1787142486778844,
+          "data":{"__type":"dk.cachet.carp.stepcount","steps":192862}}]}]
+    ''');
+
+    final batches = (responseJson as List<dynamic>)
+        .map((batch) => DataStreamBatch.fromJson(batch as Map<String, dynamic>))
+        .toList();
+
+    expect(batches.length, 2);
+    expect(batches.map((b) => b.firstSequenceId), [1, 14]);
+    expect(batches.expand((b) => b.measurements).length, 2);
+  });
+}


### PR DESCRIPTION
## What

Adds a time-window query to `carp_webservices` using the CAWS `data-stream-service/query-by-time` endpoint:

- `CarpDataStreamService().queryDataStreamByTime(dataStream, from, to)` — returns all data points whose local `updated_at` falls within the inclusive window, as one `DataStreamBatch` per contiguous run of measurements
- `DataStreamReference.getByTime(dataStream, from, to)` — convenience on the reference
- Renames `CarpDataStreamService().stream()` → `dataStream()`; the old name remains as a deprecated alias
- Shared `_toDataStreamBatches()` response mapping for both queries

## Why

The existing `getDataStream()` queries by sequence-id range, which a client cannot know without tracking upload state. Time-window queries let an app fetch "everything uploaded in the last N days" directly — used by the CARP Study App statistics page to backfill its data cards (steps, activity, sleep, mobility, heart rate) for the trailing week.

This is a CAWS-specific endpoint, so it is added on `CarpDataStreamService` rather than the core `DataStreamService` interface.

## Version

`carp_webservices` `4.2.0` → `4.3.0` (+ CHANGELOG).

## Testing

- Unit tests for the request construction and batch deserialization (`data_stream_query_by_time_test.dart`)
- Exercised end-to-end from the CARP Study App against test.carp.dk: backfill verified on device for sleep, heart rate, activity and steps