### PR TITLE
Initialize notifications before asking, and never through permission_handler

### DIFF
--- a/carp_mobile_sensing/CHANGELOG.md
+++ b/carp_mobile_sensing/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.3.2
+
+* initialize the notification plugin before asking for the notification permission - a dismissed dialog left the plugin uninitialized, and every `show()` crashed with a null icon
+* ask for the notification permission through `flutter_local_notifications` instead of `permission_handler`, which never completes its future when the dialog is dismissed - hanging `SmartPhoneClientManager.configure()` forever
+* stop requesting `SCHEDULE_EXACT_ALARM`, which Android only grants through a settings screen: notifications now schedule exactly when the permission happens to be granted, and inexactly (still while idle) otherwise
+
 ## 2.3.1
 
 * fix `duplicate column name: record_id` crash in the `record_id` SQLite migration (`SQLiteDataManager.onUpgrade`) by only adding the column/index when it isn't already there

--- a/carp_mobile_sensing/lib/infrastructure/services/local_notification_manager.dart
+++ b/carp_mobile_sensing/lib/infrastructure/services/local_notification_manager.dart
@@ -30,14 +30,7 @@ class FlutterLocalNotificationManager implements NotificationManager {
   Future<void> configure() async {
     tz.initializeTimeZones();
 
-    List<Permission> permissions = List.from([
-      Permission.notification,
-      Permission.scheduleExactAlarm,
-    ]);
-
-    var status = await permissions.request();
-    debug('$runtimeType - Permissions: $status');
-
+    // Registers the notification icon - without it every show() throws on Android.
     await FlutterLocalNotificationsPlugin().initialize(
       settings: const InitializationSettings(
         android: AndroidInitializationSettings('ic_launcher'),
@@ -47,6 +40,14 @@ class FlutterLocalNotificationManager implements NotificationManager {
           onDidReceiveNotificationResponse,
       onDidReceiveNotificationResponse: onDidReceiveNotificationResponse,
     );
+
+    // Not permission_handler: it never completes its future if the dialog is dismissed.
+    var granted = await FlutterLocalNotificationsPlugin()
+        .resolvePlatformSpecificImplementation<
+          AndroidFlutterLocalNotificationsPlugin
+        >()
+        ?.requestNotificationsPermission();
+    debug('$runtimeType - Notification permission granted: $granted');
 
     info('$runtimeType configured.');
   }
@@ -63,6 +64,13 @@ class FlutterLocalNotificationManager implements NotificationManager {
         ),
         iOS: DarwinNotificationDetails(),
       );
+
+  /// Exact alarms need `SCHEDULE_EXACT_ALARM`, which Android only grants
+  /// through a settings screen - so use them when granted, inexact otherwise.
+  Future<AndroidScheduleMode> get _scheduleMode async =>
+      await Permission.scheduleExactAlarm.isGranted
+      ? AndroidScheduleMode.exactAllowWhileIdle
+      : AndroidScheduleMode.inexactAllowWhileIdle;
 
   @override
   Future<int> createNotification({
@@ -101,7 +109,7 @@ class FlutterLocalNotificationManager implements NotificationManager {
       body: body,
       scheduledDate: time,
       notificationDetails: _platformChannelSpecifics,
-      androidScheduleMode: AndroidScheduleMode.exactAllowWhileIdle,
+      androidScheduleMode: await _scheduleMode,
     );
 
     return id;
@@ -134,7 +142,7 @@ class FlutterLocalNotificationManager implements NotificationManager {
       body: body,
       scheduledDate: time,
       notificationDetails: _platformChannelSpecifics,
-      androidScheduleMode: AndroidScheduleMode.exactAllowWhileIdle,
+      androidScheduleMode: await _scheduleMode,
       matchDateTimeComponents: recurrence,
     );
 
@@ -178,7 +186,7 @@ class FlutterLocalNotificationManager implements NotificationManager {
         body: task.description,
         scheduledDate: time,
         notificationDetails: _platformChannelSpecifics,
-        androidScheduleMode: AndroidScheduleMode.exactAllowWhileIdle,
+        androidScheduleMode: await _scheduleMode,
         payload: task.id,
       );
       task.hasNotificationBeenCreated = true;

--- a/carp_mobile_sensing/pubspec.yaml
+++ b/carp_mobile_sensing/pubspec.yaml
@@ -1,5 +1,5 @@
 name: carp_mobile_sensing
-version: 2.3.1
+version: 2.3.2
 description: Mobile Sensing Framework for Flutter. A software framework for collecting sensor data from the phone and attached wearable devices via probes. Can be extended.
 
 # Note that the following URLs to GitHub should use the old 'cph-cachet' name.
@@ -69,6 +69,8 @@ dependencies:
 #   path: ../../flutter-plugins/packages/screen_state
 
 dev_dependencies:
+  flutter_test:
+    sdk: flutter
   build_runner: any
   json_serializable: any
   test: any

--- a/carp_mobile_sensing/test/notification_test.dart
+++ b/carp_mobile_sensing/test/notification_test.dart
@@ -1,0 +1,82 @@
+import 'package:carp_mobile_sensing/carp_mobile_sensing.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+const _notifications = MethodChannel('dexterous.com/flutter/local_notifications');
+const _permissions = MethodChannel('flutter.baseflow.com/permissions/methods');
+
+// The values permission_handler sends over its method channel.
+const _denied = 0, _granted = 1;
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  /// Fakes Android: records the calls made on both plugin channels.
+  List<String> fakeAndroid({bool exactAlarmGranted = false}) {
+    final calls = <String>[];
+    debugDefaultTargetPlatformOverride = TargetPlatform.android;
+    AndroidFlutterLocalNotificationsPlugin.registerWith();
+
+    final messenger =
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+
+    messenger.setMockMethodCallHandler(_notifications, (call) async {
+      calls.add(call.method);
+      if (call.method == 'zonedSchedule') {
+        final specifics = (call.arguments as Map)['platformSpecifics'] as Map;
+        calls.add('scheduleMode=${specifics['scheduleMode']}');
+      }
+      return true;
+    });
+
+    messenger.setMockMethodCallHandler(_permissions, (call) async {
+      calls.add('permission.${call.method}');
+      return exactAlarmGranted ? _granted : _denied;
+    });
+
+    addTearDown(() {
+      debugDefaultTargetPlatformOverride = null;
+      messenger.setMockMethodCallHandler(_notifications, null);
+      messenger.setMockMethodCallHandler(_permissions, null);
+    });
+    return calls;
+  }
+
+  test('the plugin is initialized before the permission dialog', () async {
+    final calls = fakeAndroid();
+
+    await FlutterLocalNotificationManager().configure();
+
+    // initialize() is what stores the notification icon on Android. Asking
+    // first would leave every show() throwing if the dialog is dismissed.
+    expect(calls, ['initialize', 'requestNotificationsPermission']);
+  });
+
+  test('notifications schedule inexactly without SCHEDULE_EXACT_ALARM',
+      () async {
+    final calls = fakeAndroid();
+
+    await FlutterLocalNotificationManager().scheduleNotification(
+      title: 'test',
+      schedule: DateTime.now().add(const Duration(hours: 1)),
+    );
+
+    // Exact scheduling throws without the permission, which Android only
+    // grants through a settings screen.
+    expect(calls, contains('scheduleMode=inexactAllowWhileIdle'));
+  });
+
+  test('notifications schedule exactly when the permission is granted',
+      () async {
+    final calls = fakeAndroid(exactAlarmGranted: true);
+
+    await FlutterLocalNotificationManager().scheduleNotification(
+      title: 'test',
+      schedule: DateTime.now().add(const Duration(hours: 1)),
+    );
+
+    expect(calls, contains('scheduleMode=exactAllowWhileIdle'));
+  });
+}


### PR DESCRIPTION
`FlutterLocalNotificationManager.configure()` asked for permissions through `permission_handler` before initializing the plugin: a dismissed dialog left the notification icon unregistered, so every `show()` crashed with a `NullPointerException`, and `permission_handler` never completes on dismissal, so `configure()` hung the app at launch. Now initializes first and asks through `flutter_local_notifications`, which returns `false` on dismissal. Also stops requesting `SCHEDULE_EXACT_ALARM` - Android only grants it via a settings screen - and schedules inexactly when it is not held.