### PR TITLE
Serialize all permission requests through one queue

### DIFF
--- a/apps/carp_mobile_sensing_app/lib/src/app.dart
+++ b/apps/carp_mobile_sensing_app/lib/src/app.dart
@@ -24,8 +24,10 @@ class LoadingPage extends StatelessWidget {
     // Request location "always" permissions upfront.
     // Note that this is a two-step process on Android, where the user first has
     // to grant "when in use" permissions, and then "always" permissions.
-    await Permission.locationWhenInUse.request();
-    await Permission.locationAlways.request();
+    await SmartPhoneClientManager().requestPermissions([
+      Permission.locationWhenInUse,
+      Permission.locationAlways,
+    ]);
 
     // Initialize and use the CAWS backend if not in local deployment mode
     if (bloc.deploymentMode != DeploymentMode.local) {

--- a/carp_mobile_sensing/CHANGELOG.md
+++ b/carp_mobile_sensing/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.4.0
+
+* fix permission dialogs failing silently: all permission requests now go through one serialized queue, `SmartPhoneClientManager.requestPermissions()`, which asks one dialog at a time. Android denies - without showing anything - any request made while another dialog is up, and the deployment handler, probes and device managers used to ask concurrently
+* `requestPermissionsInOrder()` (the default requester) also skips already granted permissions and asks `locationWhenInUse` before `locationAlways`, as Android requires
+* `configure(permissionRequester:)` lets an app take over how the user is asked - e.g. to show a rationale before each dialog
+* `_deviceDeploymentReceived` is serialized - the deployment event fires twice on a normal launch, and the two runs used to configure and ask for permissions at the same time
+
 ## 2.3.1
 
 * fix `duplicate column name: record_id` crash in the `record_id` SQLite migration (`SQLiteDataManager.onUpgrade`) by only adding the column/index when it isn't already there

--- a/carp_mobile_sensing/lib/runtime.dart
+++ b/carp_mobile_sensing/lib/runtime.dart
@@ -42,6 +42,7 @@ part 'runtime/util/cron_parser.dart';
 part 'runtime/app_task_controller.dart';
 part 'runtime/client_manager.dart';
 part 'runtime/client_repository.dart';
+part 'runtime/permissions.dart';
 part 'runtime/study_controller.dart';
 part 'runtime/device_manager/device_controller.dart';
 part 'runtime/device_manager/device_manager.dart';

--- a/carp_mobile_sensing/lib/runtime/client_manager.dart
+++ b/carp_mobile_sensing/lib/runtime/client_manager.dart
@@ -50,6 +50,8 @@ class SmartPhoneClientManager
   final NotificationManager _notificationManager =
       FlutterLocalNotificationManager();
   bool _askForPermissions = true;
+  PermissionRequester _permissionRequester = requestPermissionsInOrder;
+  Future<void> _asking = Future.value();
   final StreamGroup<Measurement> _group = StreamGroup.broadcast();
   ClientManagerState _state = ClientManagerState.created;
   final StreamController<ClientManagerState> _controller =
@@ -58,6 +60,26 @@ class SmartPhoneClientManager
 
   /// Will this client manager ask for permission when a new study is deployed?
   bool get askForPermissions => _askForPermissions;
+
+  /// Ask the user for [permissions], using the [PermissionRequester] this
+  /// client is configured with.
+  ///
+  /// This is the one place in CAMS that talks to the OS permission dialogs.
+  /// Requests are serialized: Android denies - without showing anything - any
+  /// request made while another dialog is up, so two callers asking at once
+  /// used to make dialogs "fail silently".
+  ///
+  /// A failed requester is logged, not rethrown: callers re-check the actual
+  /// permission status afterwards anyway, and an error must not block the
+  /// requests queued behind it.
+  Future<void> requestPermissions(List<Permission> permissions) =>
+      _asking = _asking.then((_) async {
+        try {
+          await _permissionRequester(permissions);
+        } catch (error) {
+          warning('$runtimeType - Permission requester failed - $error');
+        }
+      });
 
   /// The runtime state of this client manager.
   ClientManagerState get state => _state;
@@ -129,8 +151,14 @@ class SmartPhoneClientManager
   /// Note that background mode is only supported on Android, and will be ignored on iOS.
   ///
   /// If [askForPermissions] is true (default), this client manager will
-  /// automatically ask for permissions for all sampling packages at once.
-  /// If you want the app to handle permissions itself, set this to false.
+  /// automatically ask for permissions for all sampling packages when a study
+  /// is deployed. If you want the app to handle permissions itself, set this
+  /// to false.
+  ///
+  /// The [permissionRequester] is how the user is asked, whenever CAMS needs a
+  /// permission. Defaults to [requestPermissionsInOrder], which shows the
+  /// system dialogs one at a time. Pass your own to, e.g., show a rationale
+  /// before each dialog.
   ///
   /// When this method is called, the client manager will restore the state of
   /// all previously added studies and resume data sampling in those studies if
@@ -149,11 +177,13 @@ class SmartPhoneClientManager
     String? backgroundNotificationTitle,
     String? backgroundNotificationText,
     bool askForPermissions = true,
+    PermissionRequester permissionRequester = requestPermissionsInOrder,
   }) async {
     // Fast out if already configured
     if (state.index >= ClientManagerState.configured.index) return;
 
     _askForPermissions = askForPermissions;
+    _permissionRequester = permissionRequester;
 
     // Initialize infrastructure services and the repository.
     await DeviceInfoService().init();

--- a/carp_mobile_sensing/lib/runtime/device_manager/device_managers.dart
+++ b/carp_mobile_sensing/lib/runtime/device_manager/device_managers.dart
@@ -120,16 +120,17 @@ abstract class BLEDeviceManager<
 
   @override
   @mustCallSuper
-  Future<void> onRequestPermissions() async {
-    if (Platform.isAndroid) {
-      await Permission.bluetoothScan.request();
-      await Permission.bluetoothConnect.request();
-      await Permission.locationWhenInUse.request();
-    }
-    if (Platform.isIOS) {
-      await Permission.bluetooth.request();
-    }
-  }
+  Future<void> onRequestPermissions() =>
+      SmartPhoneClientManager().requestPermissions(
+        Platform.isAndroid
+            ? [
+                Permission.bluetoothScan,
+                Permission.bluetoothConnect,
+                // BLE scanning on Android also requires location permission.
+                Permission.locationWhenInUse,
+              ]
+            : [Permission.bluetooth],
+      );
 }
 
 /// A device manager for a smartphone.

--- a/carp_mobile_sensing/lib/runtime/executors/probes.dart
+++ b/carp_mobile_sensing/lib/runtime/executors/probes.dart
@@ -112,23 +112,8 @@ abstract class Probe extends AbstractExecutor<Measure> {
     if (await arePermissionsGranted()) return true;
 
     debug('$runtimeType - Asking permission for: $permissions');
-    bool granted = true;
-
-    try {
-      final status = await permissions.request();
-      debug('$runtimeType - Permission status: $status');
-
-      granted = status.values.fold(
-        true,
-        (value, status) => value && status == PermissionStatus.granted,
-      );
-    } catch (error) {
-      addError(
-        '$runtimeType - Error trying to request permissions, error: $error',
-      );
-      return false;
-    }
-    return granted;
+    await SmartPhoneClientManager().requestPermissions(permissions);
+    return arePermissionsGranted();
   }
 
   /// Whether this probe is allowed to run.

--- a/carp_mobile_sensing/lib/runtime/permissions.dart
+++ b/carp_mobile_sensing/lib/runtime/permissions.dart
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2026 the Technical University of Denmark (DTU).
+ * Use of this source code is governed by a MIT-style license that can be
+ * found in the LICENSE file.
+ */
+
+part of '../runtime.dart';
+
+/// Asks the user for [permissions] and completes once done.
+///
+/// Lets an app take over how permissions are requested - e.g., to show a
+/// rationale before each system dialog. See [SmartPhoneClientManager.configure].
+///
+/// Whatever the user answers, CAMS re-checks the actual permission status
+/// afterwards, so a requester never needs to report back.
+///
+/// A requester runs *inside* the permission queue, so it must call
+/// `permission_handler` directly and never
+/// [SmartPhoneClientManager.requestPermissions] - that would wait on itself.
+typedef PermissionRequester =
+    Future<void> Function(List<Permission> permissions);
+
+/// Requests [permissions] one at a time, skipping those already granted.
+///
+/// This is the default [PermissionRequester].
+///
+/// One at a time is not a style choice: Android denies - without showing a
+/// dialog - any request made while another one is up, and a permission that
+/// unlocks another one can only be granted if asked first.
+Future<void> requestPermissionsInOrder(List<Permission> permissions) async {
+  final asked = <Permission>{};
+
+  for (final permission in permissions.expand(_withPrerequisite)) {
+    if (!asked.add(permission)) continue;
+    if (await permission.isGranted) continue;
+
+    final name = permission.toString().split('.').last;
+    final asking = DateTime.now();
+    final status = await permission.request();
+    final took = DateTime.now().difference(asking);
+
+    // The duration is the tell: a dialog the participant actually saw takes
+    // hundreds of ms at least. An instant denial means Android refused to
+    // show one because something else was already asking.
+    info('Permission $name: ${status.name} (${took.inMilliseconds}ms)');
+    if (took.inMilliseconds < 50 && status.isDenied) {
+      warning(
+        'Permission $name was denied without a dialog - another request '
+        'was already in progress.',
+      );
+    }
+  }
+}
+
+/// Android only offers `locationAlways` once `locationWhenInUse` is granted,
+/// and only in a separate dialog. Climbing that ladder here means callers can
+/// declare the permissions they need in any order and still get asked correctly.
+Iterable<Permission> _withPrerequisite(Permission permission) =>
+    permission == Permission.locationAlways
+    ? [Permission.locationWhenInUse, permission]
+    : [permission];

--- a/carp_mobile_sensing/lib/runtime/study_controller.dart
+++ b/carp_mobile_sensing/lib/runtime/study_controller.dart
@@ -121,12 +121,29 @@ class SmartphoneStudyController {
   /// Handles updates of the [deployment] status.
   Future<void> _deploymentStatusReceived() async {}
 
+  /// Serializes [_deviceDeploymentReceived], which the event stream fires
+  /// again while a previous run is still awaiting - twice on a normal launch.
+  /// Two runs at once configure and ask for permissions concurrently.
+  Future<void> _configuring = Future.value();
+
   /// Handles the reception of a new or updated [deployment].
   ///
   /// This entails configuring devices, data manager, and executor to get
   /// ready to handle sampling of data. Data sampling is started if the
   /// [SmartphoneStudy.samplingState] is in a resumed state.
-  Future<void> _deviceDeploymentReceived() async {
+  ///
+  /// A failed run is logged, not rethrown - nothing awaits the event handler,
+  /// and an error must not block the runs queued behind it.
+  Future<void> _deviceDeploymentReceived() =>
+      _configuring = _configuring.then((_) async {
+        try {
+          await _configureDeployment();
+        } catch (error) {
+          warning('$runtimeType - Configuring deployment failed - $error');
+        }
+      });
+
+  Future<void> _configureDeployment() async {
     debug(
       '$runtimeType - Received device deployment: ${deployment?.studyDeploymentId}',
     );
@@ -189,7 +206,7 @@ class SmartphoneStudyController {
 
     // start the study and restart data sampling
     study.samplingState = existingSamplingStatus;
-    _start();
+    await _start();
 
     var statusMsg =
         '===============================================================\n'
@@ -356,9 +373,8 @@ class SmartphoneStudyController {
   /// This method is only relevant on Android, and does nothing on iOS.
   /// iOS automatically asks for permissions when a resource is accessed.
   ///
-  /// Note that location permissions are never asked for in this method, since
-  /// they can cause issues when asking for multiple permissions at once.
-  /// Location permissions should be handled separately in the app.
+  /// Permissions are asked for one at a time, through
+  /// [SmartPhoneClientManager.requestPermissions].
   Future<void> askForAllPermissions() async {
     if (deployment == null) {
       warning(
@@ -389,29 +405,15 @@ class SmartphoneStudyController {
     );
 
     if (permissions.isNotEmpty) {
-      // Never ask for location permissions.
-      // Will mess it up when requesting multiple permissions at once.
-      permissions
-        ..remove(Permission.location)
-        ..remove(Permission.locationWhenInUse)
-        ..remove(Permission.locationAlways);
+      info(
+        '$runtimeType - Asking for permissions for all measures in this deployment...',
+      );
+      await SmartPhoneClientManager().requestPermissions(permissions.toList());
 
-      try {
-        info(
-          '$runtimeType - Asking for permissions for all measures in this deployment...',
-        );
-        _permissions = await permissions.toList().request();
-
-        debug('$runtimeType - Permissions granted: $_permissions');
-
-        _permissions?.forEach(
-          (permission, status) => info(
-            '$runtimeType - Permission status for ${permission.toString().split('.').last} : ${status.name}',
-          ),
-        );
-      } catch (error) {
-        warning('$runtimeType - Error requesting permissions - error: $error');
-      }
+      _permissions = {
+        for (final permission in permissions) permission: await permission.status,
+      };
+      debug('$runtimeType - Permissions: $_permissions');
     }
   }
 

--- a/carp_mobile_sensing/pubspec.yaml
+++ b/carp_mobile_sensing/pubspec.yaml
@@ -1,5 +1,5 @@
 name: carp_mobile_sensing
-version: 2.3.1
+version: 2.4.0
 description: Mobile Sensing Framework for Flutter. A software framework for collecting sensor data from the phone and attached wearable devices via probes. Can be extended.
 
 # Note that the following URLs to GitHub should use the old 'cph-cachet' name.
@@ -69,6 +69,8 @@ dependencies:
 #   path: ../../flutter-plugins/packages/screen_state
 
 dev_dependencies:
+  flutter_test:
+    sdk: flutter
   build_runner: any
   json_serializable: any
   test: any

--- a/carp_mobile_sensing/test/permissions_test.dart
+++ b/carp_mobile_sensing/test/permissions_test.dart
@@ -1,0 +1,194 @@
+import 'dart:async';
+import 'dart:math';
+
+import 'package:carp_mobile_sensing/carp_mobile_sensing.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:permission_handler/permission_handler.dart';
+
+const _channel = MethodChannel('flutter.baseflow.com/permissions/methods');
+
+// The values permission_handler sends over its method channel.
+const _denied = 0, _granted = 1;
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  /// Fake the OS: records the calls; grants whatever is asked for, unless
+  /// [denyAll] - then the user taps "Don't allow" on every dialog.
+  List<String> fakePermissionHandler({
+    Set<int> alreadyGranted = const {},
+    bool denyAll = false,
+  }) {
+    final calls = <String>[];
+    final granted = {...alreadyGranted};
+
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(_channel, (call) async {
+          switch (call.method) {
+            case 'checkPermissionStatus':
+              return granted.contains(call.arguments as int)
+                  ? _granted
+                  : _denied;
+            case 'requestPermissions':
+              final requested = (call.arguments as List).cast<int>();
+              calls.add('request(${requested.join(',')})');
+              if (denyAll) return {for (final p in requested) p: _denied};
+              granted.addAll(requested);
+              return {for (final p in requested) p: _granted};
+            default:
+              return null;
+          }
+        });
+
+    addTearDown(
+      () => TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(_channel, null),
+    );
+    return calls;
+  }
+
+  String request(Permission p) => 'request(${p.value})';
+
+  test('permissions are requested one at a time, in declared order', () async {
+    final calls = fakePermissionHandler();
+
+    await requestPermissionsInOrder([
+      Permission.locationWhenInUse,
+      Permission.locationAlways,
+    ]);
+
+    // One request per permission, in order. Batching them into a single
+    // request() would break Android's location ladder: locationAlways is only
+    // offered once locationWhenInUse is granted.
+    expect(calls, [
+      request(Permission.locationWhenInUse),
+      request(Permission.locationAlways),
+    ]);
+  });
+
+  test('locationAlways always climbs the ladder, however declared', () async {
+    final calls = fakePermissionHandler();
+
+    await requestPermissionsInOrder([
+      Permission.bluetoothScan,
+      Permission.locationAlways,
+    ]);
+
+    expect(calls, [
+      request(Permission.bluetoothScan),
+      request(Permission.locationWhenInUse),
+      request(Permission.locationAlways),
+    ]);
+  });
+
+  test('a permission listed twice is only asked for once', () async {
+    final calls = fakePermissionHandler();
+
+    await requestPermissionsInOrder([
+      Permission.locationAlways,
+      Permission.locationWhenInUse, // already covered by the ladder above
+    ]);
+
+    expect(calls, [
+      request(Permission.locationWhenInUse),
+      request(Permission.locationAlways),
+    ]);
+  });
+
+  test('already granted permissions are not asked for again', () async {
+    final calls = fakePermissionHandler(
+      alreadyGranted: {Permission.locationWhenInUse.value},
+    );
+
+    await requestPermissionsInOrder([
+      Permission.locationWhenInUse,
+      Permission.locationAlways,
+    ]);
+
+    expect(calls, [request(Permission.locationAlways)]);
+  });
+
+  test('concurrent permission requests never overlap', () async {
+    // Fake an OS whose dialog stays up until the user answers: each request
+    // blocks on a completer. Android denies - without showing - any request
+    // that arrives while another dialog is up, so at most one may be in flight.
+    final dialogs = <Completer<void>>[];
+    var inFlight = 0, maxInFlight = 0;
+    final granted = <int>{};
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(_channel, (call) async {
+          switch (call.method) {
+            case 'checkPermissionStatus':
+              return granted.contains(call.arguments as int)
+                  ? _granted
+                  : _denied;
+            case 'requestPermissions':
+              final dialog = Completer<void>();
+              dialogs.add(dialog);
+              maxInFlight = max(maxInFlight, ++inFlight);
+              await dialog.future;
+              inFlight--;
+              final asked = (call.arguments as List).cast<int>();
+              granted.addAll(asked);
+              return {for (final p in asked) p: _granted};
+            default:
+              return null;
+          }
+        });
+    addTearDown(
+      () => TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(_channel, null),
+    );
+
+    // Deployment events, probes and devices all ask at once on a normal launch.
+    final client = SmartPhoneClientManager();
+    final permissions = [Permission.locationWhenInUse, Permission.locationAlways];
+    final done = Future.wait([
+      client.requestPermissions(permissions),
+      client.requestPermissions(permissions),
+      client.requestPermissions([Permission.notification]),
+    ]);
+
+    // The user answers one dialog at a time; a new one appears only after.
+    for (var answered = 0; answered < 3; answered++) {
+      await pumpEventQueue();
+      expect(dialogs.length, answered + 1, reason: 'exactly one dialog up');
+      dialogs[answered].complete();
+    }
+    await done;
+
+    expect(maxInFlight, 1);
+    // The second run found location granted by the first, and asked nothing.
+    expect(dialogs.length, 3);
+  });
+
+  test('a failed permission request does not block later requests', () async {
+    // A request that throws must not poison the queue - a study that fails
+    // must not block permissions for every study after it.
+    var requests = 0;
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(_channel, (call) async {
+          switch (call.method) {
+            case 'checkPermissionStatus':
+              return _denied;
+            case 'requestPermissions':
+              if (++requests == 1) throw PlatformException(code: 'ERROR');
+              final asked = (call.arguments as List).cast<int>();
+              return {for (final p in asked) p: _granted};
+            default:
+              return null;
+          }
+        });
+    addTearDown(
+      () => TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(_channel, null),
+    );
+
+    final client = SmartPhoneClientManager();
+    await client.requestPermissions([Permission.notification]); // throws inside
+    await client.requestPermissions([Permission.notification]);
+
+    expect(requests, 2);
+  });
+}

--- a/packages/carp_context_package/CHANGELOG.md
+++ b/packages/carp_context_package/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.1.1
+
+* `LocationManager.requestPermission()` asks through `SmartPhoneClientManager.requestPermissions()`, so it no longer collides with other permission dialogs; it now asks 'when in use' then 'always'
+* background mode is only enabled once `locationAlways` is granted - the `location` plugin otherwise pops its own dialog outside the queue
+
 ## 2.1.0
 
 * require `carp_serializable` ^3.0.0, which replaces the built-in `Uuid` with the [uuid](https://pub.dev/packages/uuid) package

--- a/packages/carp_context_package/lib/src/location_manager.dart
+++ b/packages/carp_context_package/lib/src/location_manager.dart
@@ -98,24 +98,26 @@ class LocationManager {
   /// opens the Settings page on Android / iOS.
   /// This method is, however, **NOT** used by this context sampling package, since
   /// handling of permissions should be taken care of on an app level.
+  ///
+  /// Goes through [SmartPhoneClientManager.requestPermissions] so it never
+  /// collides with another dialog. Asks 'when in use' first, then 'always'.
   Future<PermissionStatus> requestPermission() async {
     debug('$runtimeType - Requesting permission to access location...');
 
-    var permissionGranted = await _provider.hasPermission();
-    if (permissionGranted == location.PermissionStatus.denied) {
-      permissionGranted = await _provider.requestPermission();
-      if (permissionGranted != location.PermissionStatus.granted) {
-        warning(
-          "$runtimeType - The user opted not to allow collection of location data. "
-          "The only way to change the permission's status now is to let the "
-          "user manually enables it in the system settings.",
-        );
-      }
+    await SmartPhoneClientManager().requestPermissions([
+      Permission.locationWhenInUse,
+      Permission.locationAlways,
+    ]);
+
+    final granted = await hasPermission();
+    if (!granted) {
+      warning(
+        "$runtimeType - The user opted not to allow collection of location data. "
+        "The only way to change the permission's status now is to let the "
+        "user manually enables it in the system settings.",
+      );
     }
-
-    debug('$runtimeType - Permission: $permissionGranted');
-
-    return permissionGranted == location.PermissionStatus.granted ? PermissionStatus.granted : PermissionStatus.denied;
+    return granted ? PermissionStatus.granted : PermissionStatus.denied;
   }
 
   /// Enable the [LocationManager] for accessing location also when the app is
@@ -128,31 +130,36 @@ class LocationManager {
   ///
   /// After the location manager is enabled, configuration can be done via the
   /// [configure] method.
-  Future<void> enable() async {
-    // fast out if already enabled
-    if (enabled) return;
+  Future<void>? _enabling;
 
-    info('Enabling $runtimeType...');
-    _enabled = false;
+  Future<void> enable() => _enabling ??= _enable().whenComplete(() => _enabling = null);
 
-    bool serviceEnabled = await _provider.serviceEnabled();
-    if (!serviceEnabled) {
-      serviceEnabled = await _provider.requestService();
+  Future<void> _enable() async {
+    if (!enabled) {
+      info('Enabling $runtimeType...');
+
+      bool serviceEnabled = await _provider.serviceEnabled();
       if (!serviceEnabled) {
-        warning('$runtimeType - Location service could not be enabled.');
-        return;
+        serviceEnabled = await _provider.requestService();
+        if (!serviceEnabled) {
+          warning('$runtimeType - Location service could not be enabled.');
+          return;
+        }
+      }
+      _enabled = true;
+    }
+
+    // Retried on every call: the plugin natively pops the 'location always'
+    // dialog here if not granted, outside CAMS' permission queue - so only
+    // enable background mode once the permission is there.
+    if (!await _provider.isBackgroundModeEnabled() && await Permission.locationAlways.isGranted) {
+      try {
+        final backgroundMode = await _provider.enableBackgroundMode();
+        info('$runtimeType - Location service enabled, background mode: $backgroundMode');
+      } catch (error) {
+        warning('$runtimeType - Could not enable background mode - $error');
       }
     }
-    _enabled = true;
-    bool backgroundMode = false;
-
-    try {
-      backgroundMode = await _provider.enableBackgroundMode();
-    } catch (error) {
-      warning('$runtimeType - Could not enable background mode - $error');
-    }
-
-    info('$runtimeType - Location service enabled, background mode: $backgroundMode');
   }
 
   LocationService? _configuration;
@@ -193,7 +200,9 @@ class LocationManager {
         );
 
         // If not granted, try to request 'when in use' permission.
-        await Permission.locationWhenInUse.request();
+        await SmartPhoneClientManager().requestPermissions([
+          Permission.locationWhenInUse,
+        ]);
       }
 
       // Change notification options - only on Android.

--- a/packages/carp_context_package/pubspec.yaml
+++ b/packages/carp_context_package/pubspec.yaml
@@ -1,5 +1,5 @@
 name: carp_context_package
-version: 2.1.0
+version: 2.1.1
 description: CARP context sampling package. Samples location, mobility, activity, weather, air-quality, and geofence.
 homepage: https://github.com/cph-cachet/carp.sensing-flutter
 repository: https://github.com/cph-cachet/carp.sensing-flutter/tree/main/packages/carp_context_package
@@ -26,7 +26,7 @@ dependencies:
  
   carp_serializable: ^3.0.0
   carp_core: ^2.2.0
-  carp_mobile_sensing: ^2.2.0
+  carp_mobile_sensing: ^2.4.0
  
   json_annotation: ^4.8.0
   permission_handler: '>=11.0.0 <13.0.0'


### PR DESCRIPTION
Fixes #616

All permission requests now go through one serialized queue in `SmartPhoneClientManager.requestPermissions()`, so only one dialog is ever open at a time. `locationWhenInUse` is asked before `locationAlways`, since Android only offers background location once foreground is granted.
