### PR TITLE
fix(context): declare the location permissions for askForAllPermissions()

### DIFF
--- a/packages/carp_context_package/lib/src/context_package.dart
+++ b/packages/carp_context_package/lib/src/context_package.dart
@@ -136,27 +136,27 @@ class LocationSamplingPackage extends SmartphoneSamplingPackage {
   DataTypeSamplingSchemeMap get samplingSchemes =>
       DataTypeSamplingSchemeMap.from([
         DataTypeSamplingScheme(
-          DataTypeMetaData(
+          CamsDataTypeMetaData(
             type: ContextSamplingPackage.LOCATION,
             displayName: "Location",
             timeType: DataTimeType.POINT,
-            // permissions: [Permission.locationAlways],
+            permissions: [Permission.locationAlways],
           ),
         ),
         DataTypeSamplingScheme(
-          DataTypeMetaData(
+          CamsDataTypeMetaData(
             type: ContextSamplingPackage.GEOFENCE,
             displayName: "Geofence",
             timeType: DataTimeType.POINT,
-            // permissions: [Permission.locationAlways],
+            permissions: [Permission.locationAlways],
           ),
         ),
         DataTypeSamplingScheme(
-          DataTypeMetaData(
+          CamsDataTypeMetaData(
             type: ContextSamplingPackage.MOBILITY,
             displayName: "Mobility",
             timeType: DataTimeType.POINT,
-            // permissions: [Permission.locationAlways],
+            permissions: [Permission.locationAlways],
           ),
           MobilitySamplingConfiguration(
             placeRadius: 50,
@@ -190,10 +190,11 @@ class AirQualitySamplingPackage extends SmartphoneSamplingPackage {
   DataTypeSamplingSchemeMap get samplingSchemes =>
       DataTypeSamplingSchemeMap.from([
         DataTypeSamplingScheme(
-          DataTypeMetaData(
+          CamsDataTypeMetaData(
             type: ContextSamplingPackage.AIR_QUALITY,
             displayName: "Air Quality",
             timeType: DataTimeType.POINT,
+            permissions: [Permission.locationWhenInUse],
           ),
         ),
       ]);
@@ -217,10 +218,11 @@ class WeatherSamplingPackage extends SmartphoneSamplingPackage {
   DataTypeSamplingSchemeMap get samplingSchemes =>
       DataTypeSamplingSchemeMap.from([
         DataTypeSamplingScheme(
-          DataTypeMetaData(
+          CamsDataTypeMetaData(
             type: ContextSamplingPackage.WEATHER,
             displayName: "Weather",
             timeType: DataTimeType.POINT,
+            permissions: [Permission.locationWhenInUse],
           ),
         ),
       ]);


### PR DESCRIPTION
Stacked on #614.

`askForAllPermissions()` only asks for what a `CamsDataTypeMetaData` declares; the location, geofence, mobility, weather and air quality schemes used a plain `DataTypeMetaData`, so nothing was asked up front and the location plugin asked natively mid-study, outside the queue. Safe to declare now that #614 asks one dialog at a time, `whenInUse` before `always`.