### PR TITLE
fix(ios): request study permissions and recover sensing connections

### DIFF
--- a/carp_mobile_sensing/CHANGELOG.md
+++ b/carp_mobile_sensing/CHANGELOG.md
@@ -3,6 +3,7 @@
 * fix permission dialogs failing silently: all permission requests now go through one serialized queue, `SmartPhoneClientManager.requestPermissions()`, which asks one dialog at a time. Android denies - without showing anything - any request made while another dialog is up, and the deployment handler, probes and device managers used to ask concurrently
 * `requestPermissionsInOrder()` (the default requester) also skips already granted permissions and asks `locationWhenInUse` before `locationAlways`, as Android requires
 * `configure(permissionRequester:)` lets an app take over how the user is asked - e.g. to show a rationale before each dialog
+* `askForAllPermissions()` and `Probe.requestPermissions()` now also ask on iOS. They skipped it because batching `List<Permission>.request()` is flaky on iOS; one at a time is not. `locationAlways` and `notification` are never auto-prompted by iOS, so studies needing them used to depend on the app asking by hand
 * `_deviceDeploymentReceived` is serialized - the deployment event fires twice on a normal launch, and the two runs used to configure and ask for permissions at the same time
 
 ## 2.3.1

--- a/carp_mobile_sensing/lib/domain/core/data_types.dart
+++ b/carp_mobile_sensing/lib/domain/core/data_types.dart
@@ -38,7 +38,14 @@ class CamsDataTypeMetaData extends DataTypeMetaData {
   ///
   /// For Android permission in the Manifest.xml file,
   /// see [Manifest.permission](https://developer.android.com/reference/android/Manifest.permission.html)
-  List<Permission> permissions;
+  ///
+  /// Declare the Android group; on iOS the Android-only groups are read as
+  /// their iOS counterpart ([Permission.activityRecognition] ->
+  /// [Permission.sensors], [Permission.bluetoothScan] -> [Permission.bluetooth]).
+  List<Permission> get permissions =>
+      Platform.isIOS ? _permissions.map(_onIOS).toList() : _permissions;
+  set permissions(List<Permission> permissions) => _permissions = permissions;
+  List<Permission> _permissions;
 
   /// Create a new description of a data [type] with some [displayName].
   ///
@@ -50,8 +57,8 @@ class CamsDataTypeMetaData extends DataTypeMetaData {
     super.displayName,
     super.timeType,
     this.dataEventType = DataEventType.EVENT,
-    this.permissions = const [],
-  });
+    List<Permission> permissions = const [],
+  }) : _permissions = permissions;
 
   /// Create a new description of a data type based on the [dataTypeMetaData].
   ///
@@ -60,13 +67,22 @@ class CamsDataTypeMetaData extends DataTypeMetaData {
   CamsDataTypeMetaData.fromDataTypeMetaData({
     required DataTypeMetaData dataTypeMetaData,
     this.dataEventType = DataEventType.EVENT,
-    this.permissions = const [],
-  }) : super(
+    List<Permission> permissions = const [],
+  }) : _permissions = permissions,
+       super(
          type: dataTypeMetaData.type,
          displayName: dataTypeMetaData.displayName,
          timeType: dataTypeMetaData.timeType,
        );
 }
+
+/// permission_handler has no iOS strategy for these Android-only groups - they
+/// come back permanentlyDenied without a dialog - so ask for the iOS one.
+Permission _onIOS(Permission permission) => switch (permission) {
+  Permission.activityRecognition => Permission.sensors,
+  Permission.bluetoothScan => Permission.bluetooth,
+  _ => permission,
+};
 
 /// Contains CAMS data type definitions similar to CARP Core [CarpDataTypes].
 class CamsDataTypes {

--- a/carp_mobile_sensing/lib/infrastructure/services/local_notification_manager.dart
+++ b/carp_mobile_sensing/lib/infrastructure/services/local_notification_manager.dart
@@ -30,10 +30,10 @@ class FlutterLocalNotificationManager implements NotificationManager {
   Future<void> configure() async {
     tz.initializeTimeZones();
 
-    List<Permission> permissions = List.from([
+    List<Permission> permissions = [
       Permission.notification,
-      Permission.scheduleExactAlarm,
-    ]);
+      if (Platform.isAndroid) Permission.scheduleExactAlarm,
+    ];
 
     var status = await permissions.request();
     debug('$runtimeType - Permissions: $status');

--- a/carp_mobile_sensing/lib/runtime/executors/probes.dart
+++ b/carp_mobile_sensing/lib/runtime/executors/probes.dart
@@ -102,12 +102,7 @@ abstract class Probe extends AbstractExecutor<Measure> {
 
   /// Request the permissions needed for this probe to run.
   /// Return true if all permissions are granted.
-  /// Only used on Android - iOS automatically request permissions when
-  /// a resource (like the microphone) is accessed.
   Future<bool> requestPermissions() async {
-    // fast out if on iOS - permissions are automatically requested
-    if (Platform.isIOS) return true;
-
     // fast out if already have permissions
     if (await arePermissionsGranted()) return true;
 
@@ -118,11 +113,10 @@ abstract class Probe extends AbstractExecutor<Measure> {
 
   /// Whether this probe is allowed to run.
   ///
-  /// On Android the [SmartphoneStudyController] requests all deployment
-  /// permissions in a single batch ([SmartphoneStudyController.askForAllPermissions]),
-  /// so probes only check - requesting again here would collide, as
-  /// permission_handler forbids concurrent requests. On iOS permissions are
-  /// requested automatically when a resource is accessed.
+  /// The [SmartphoneStudyController] asks for all deployment permissions up
+  /// front ([SmartphoneStudyController.askForAllPermissions]), so probes only
+  /// check. Not on iOS: permission_handler reports Android-only groups (e.g.
+  /// activityRecognition, phone) as denied there, and iOS prompts on first use.
   Future<bool> hasRequiredPermissions() async =>
       Platform.isIOS ? true : await arePermissionsGranted();
 

--- a/carp_mobile_sensing/lib/runtime/permissions.dart
+++ b/carp_mobile_sensing/lib/runtime/permissions.dart
@@ -34,21 +34,8 @@ Future<void> requestPermissionsInOrder(List<Permission> permissions) async {
     if (!asked.add(permission)) continue;
     if (await permission.isGranted) continue;
 
-    final name = permission.toString().split('.').last;
-    final asking = DateTime.now();
     final status = await permission.request();
-    final took = DateTime.now().difference(asking);
-
-    // The duration is the tell: a dialog the participant actually saw takes
-    // hundreds of ms at least. An instant denial means Android refused to
-    // show one because something else was already asking.
-    info('Permission $name: ${status.name} (${took.inMilliseconds}ms)');
-    if (took.inMilliseconds < 50 && status.isDenied) {
-      warning(
-        'Permission $name was denied without a dialog - another request '
-        'was already in progress.',
-      );
-    }
+    info('Permission ${permission.toString().split('.').last}: ${status.name}');
   }
 }
 

--- a/carp_mobile_sensing/lib/runtime/study_controller.dart
+++ b/carp_mobile_sensing/lib/runtime/study_controller.dart
@@ -370,21 +370,12 @@ class SmartphoneStudyController {
   /// should be called after deployment has taken place but before this controller
   /// is resumed.
   ///
-  /// This method is only relevant on Android, and does nothing on iOS.
-  /// iOS automatically asks for permissions when a resource is accessed.
-  ///
   /// Permissions are asked for one at a time, through
-  /// [SmartPhoneClientManager.requestPermissions].
+  /// [SmartPhoneClientManager.requestPermissions], on both Android and iOS.
   Future<void> askForAllPermissions() async {
     if (deployment == null) {
       warning(
         '$runtimeType - No deployment available. Skipping requesting permissions.',
-      );
-      return;
-    }
-    if (Platform.isIOS) {
-      warning(
-        '$runtimeType - Requesting all permissions at once is not feasible on iOS. Skipping this.',
       );
       return;
     }

--- a/carp_mobile_sensing/lib/runtime/study_controller.dart
+++ b/carp_mobile_sensing/lib/runtime/study_controller.dart
@@ -510,9 +510,11 @@ class SmartphoneStudyController {
       );
     }
 
-    // Ask for permissions for all measures in this deployment
+    // Ask for permissions for all measures in this deployment, then retry
+    // connecting devices that were skipped earlier for lack of permissions.
     if (SmartPhoneClientManager().askForPermissions) {
       await askForAllPermissions();
+      await _connectAllConnectableDevices();
     }
 
     // Finally, resume/pause data sampling based on the current sampling state of this study.

--- a/packages/carp_connectivity_package/lib/connectivity_probes.dart
+++ b/packages/carp_connectivity_package/lib/connectivity_probes.dart
@@ -98,30 +98,31 @@ class BluetoothProbe extends BufferingPeriodicStreamProbe {
   void onSamplingStart() {
     _data = Bluetooth();
 
-    try {
-      FlutterBluePlus.startScan(
-        withServices: services,
-        withRemoteIds: remoteIds,
-        timeout:
-            samplingConfiguration?.duration ??
-            const Duration(milliseconds: DEFAULT_TIMEOUT),
-      );
-    } catch (error) {
-      FlutterBluePlus.stopScan();
+    // startScan is async - a plain try/catch would not catch its errors
+    // (e.g. adapter not ready yet on iOS: CBManagerStateUnknown).
+    FlutterBluePlus.startScan(
+      withServices: services,
+      withRemoteIds: remoteIds,
+      timeout:
+          samplingConfiguration?.duration ??
+          const Duration(milliseconds: DEFAULT_TIMEOUT),
+    ).catchError((Object error) {
       _data = Error(message: 'Error scanning for bluetooth - $error');
-    }
+    });
   }
 
   @override
   void onSamplingEnd() {
-    FlutterBluePlus.stopScan();
+    FlutterBluePlus.stopScan().catchError((Object error) {
+      _data = Error(message: 'Error stopping bluetooth scan - $error');
+    });
 
     if (_data is Bluetooth) (_data as Bluetooth).endScan = DateTime.now();
   }
 
   @override
   void onSamplingData(event) {
-    if (event is List<ScanResult>) {
+    if (_data is Bluetooth && event is List<ScanResult>) {
       (_data as Bluetooth).addBluetoothDevicesFromScanResults(event);
     }
   }

--- a/packages/carp_connectivity_package/test/bluetooth_scan_failure_test.dart
+++ b/packages/carp_connectivity_package/test/bluetooth_scan_failure_test.dart
@@ -1,0 +1,27 @@
+import 'package:carp_connectivity_package/connectivity.dart';
+import 'package:carp_core/carp_core.dart' as carp;
+import 'package:carp_mobile_sensing/carp_mobile_sensing.dart';
+import 'package:flutter_blue_plus/flutter_blue_plus.dart';
+import 'package:test/test.dart';
+
+class _BluetoothProbe extends BluetoothProbe {
+  @override
+  PeriodicSamplingConfiguration get samplingConfiguration =>
+      PeriodicSamplingConfiguration(
+        interval: const Duration(minutes: 1),
+        duration: const Duration(seconds: 4),
+      );
+}
+
+void main() {
+  test('scan startup failure is data, and late results cannot overwrite it', () async {
+    // No native Bluetooth platform in this test: startScan fails asynchronously.
+    final probe = _BluetoothProbe();
+    probe.onSamplingStart();
+    await Future<void>.delayed(Duration.zero);
+
+    expect((await probe.getMeasurement())?.data, isA<carp.Error>());
+    probe.onSamplingData(<ScanResult>[]);
+    expect((await probe.getMeasurement())?.data, isA<carp.Error>());
+  });
+}

--- a/packages/carp_context_package/lib/src/context_package.dart
+++ b/packages/carp_context_package/lib/src/context_package.dart
@@ -136,27 +136,27 @@ class LocationSamplingPackage extends SmartphoneSamplingPackage {
   DataTypeSamplingSchemeMap get samplingSchemes =>
       DataTypeSamplingSchemeMap.from([
         DataTypeSamplingScheme(
-          DataTypeMetaData(
+          CamsDataTypeMetaData(
             type: ContextSamplingPackage.LOCATION,
             displayName: "Location",
             timeType: DataTimeType.POINT,
-            // permissions: [Permission.locationAlways],
+            permissions: [Permission.locationAlways],
           ),
         ),
         DataTypeSamplingScheme(
-          DataTypeMetaData(
+          CamsDataTypeMetaData(
             type: ContextSamplingPackage.GEOFENCE,
             displayName: "Geofence",
             timeType: DataTimeType.POINT,
-            // permissions: [Permission.locationAlways],
+            permissions: [Permission.locationAlways],
           ),
         ),
         DataTypeSamplingScheme(
-          DataTypeMetaData(
+          CamsDataTypeMetaData(
             type: ContextSamplingPackage.MOBILITY,
             displayName: "Mobility",
             timeType: DataTimeType.POINT,
-            // permissions: [Permission.locationAlways],
+            permissions: [Permission.locationAlways],
           ),
           MobilitySamplingConfiguration(
             placeRadius: 50,
@@ -190,10 +190,11 @@ class AirQualitySamplingPackage extends SmartphoneSamplingPackage {
   DataTypeSamplingSchemeMap get samplingSchemes =>
       DataTypeSamplingSchemeMap.from([
         DataTypeSamplingScheme(
-          DataTypeMetaData(
+          CamsDataTypeMetaData(
             type: ContextSamplingPackage.AIR_QUALITY,
             displayName: "Air Quality",
             timeType: DataTimeType.POINT,
+            permissions: [Permission.locationWhenInUse],
           ),
         ),
       ]);
@@ -217,10 +218,11 @@ class WeatherSamplingPackage extends SmartphoneSamplingPackage {
   DataTypeSamplingSchemeMap get samplingSchemes =>
       DataTypeSamplingSchemeMap.from([
         DataTypeSamplingScheme(
-          DataTypeMetaData(
+          CamsDataTypeMetaData(
             type: ContextSamplingPackage.WEATHER,
             displayName: "Weather",
             timeType: DataTimeType.POINT,
+            permissions: [Permission.locationWhenInUse],
           ),
         ),
       ]);


### PR DESCRIPTION
Follows the permission serializer (#614, merged).

`askForAllPermissions()` and `Probe.requestPermissions()` skipped iOS because batching `List<Permission>.request()` is flaky there. The serializer is in: every request is a single permission, so the skip is obsolete - and iOS never auto-prompts for `locationAlways` or `notification`, so studies needing them depended on the app asking by hand. `hasRequiredPermissions()` keeps its iOS short-circuit since `permission_handler` reports Android-only groups as denied on iOS.

- Map motion and Bluetooth scan permissions to their supported iOS permission groups.
- Declare location permissions for location, geofence, mobility, weather and air-quality measures so they are requested before sampling.
- Retry device connections after requesting study permissions, so newly granted services can connect.
- Catch asynchronous Bluetooth scan errors and ignore late results after a failed scan; add a regression test.
- Request the exact-alarm permission only on Android, not iOS.
